### PR TITLE
feat: Album art visualizer, universal macOS binary, Oklch improvements

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,22 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Build
+        if: matrix.os != 'macos-latest'
         run: cargo build --release --verbose
+
+      - name: Add macOS targets
+        if: matrix.os == 'macos-latest'
+        run: rustup target add x86_64-apple-darwin aarch64-apple-darwin
+
+      - name: Build universal binary (macOS)
+        if: matrix.os == 'macos-latest'
+        run: |
+          cargo build --release --target x86_64-apple-darwin
+          cargo build --release --target aarch64-apple-darwin
+          lipo -create \
+            target/x86_64-apple-darwin/release/audioleaf \
+            target/aarch64-apple-darwin/release/audioleaf \
+            -output target/release/audioleaf-universal
 
       - name: Run tests
         run: cargo test --verbose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,7 +109,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "audioleaf"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -527,9 +527,9 @@ checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "flate2"
-version = "1.1.7"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2152dbcb980c05735e2a651d96011320a949eb31a0c8b38b72645ce97dec676"
+checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -869,9 +869,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -883,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -1675,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "b6eff9328d40131d43bd911d42d79eb6a47312002a4daefc9e37f17e74a7701a"
 dependencies = [
  "base64",
  "bytes",
@@ -1949,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "siphasher"
@@ -2257,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16,21 +25,21 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alsa"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+checksum = "812947049edcd670a82cd5c73c3661d2e58468577ba8489de58e1a73c04cbd5d"
 dependencies = [
  "alsa-sys",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if",
  "libc",
 ]
 
 [[package]]
 name = "alsa-sys"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+checksum = "ad7569085a265dd3f607ebecce7458eaab2132a84393534c95b18dcbc3f31e04"
 dependencies = [
  "libc",
  "pkg-config",
@@ -38,9 +47,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -53,15 +62,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -88,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "approx"
@@ -102,6 +111,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,15 +127,19 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "audioleaf"
-version = "3.3.0"
+version = "3.5.0"
 dependencies = [
  "anyhow",
+ "auto-palette",
  "clap",
  "cpal",
  "dasp_sample",
  "dirs",
+ "image 0.25.10",
  "macroquad",
  "num-complex",
+ "objc2",
+ "objc2-foundation",
  "palette",
  "pollster",
  "ratatui",
@@ -128,16 +150,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto-palette"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3a3dd8bb9a7414943e5ccc56d75083721bf2286f2b25e6e2eb9eda8ac97d7f"
+dependencies = [
+ "image 0.25.10",
+ "num-traits",
+ "rustc-hash",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94bffc006df10ac2a68c83692d734a465f8ee6c5b384d8545a636f81d858f4bf"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4321e568ed89bb5a7d291a7f37997c2c0df89809d7b6d12062c81ddb54aa782e"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -147,15 +218,33 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.0"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "by_address"
@@ -165,9 +254,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "byteorder"
@@ -176,16 +265,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
-name = "bytes"
-version = "1.11.0"
+name = "byteorder-lite"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
+name = "bytes"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "castaway"
@@ -198,11 +287,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.49"
+version = "1.2.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
+checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -219,10 +310,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "clap"
-version = "4.5.53"
+name = "cfg_aliases"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clap"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -230,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.53"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -242,21 +339,30 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.49"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "color_quant"
@@ -266,9 +372,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -282,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -292,6 +398,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -305,6 +420,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,11 +437,11 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
+checksum = "d15c3c3cee7c087938f7ad1c3098840b3ef1f1bdc7f6e496336c3b1e7a6f3914"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "libc",
  "objc2-audio-toolbox",
  "objc2-core-audio",
@@ -326,9 +451,9 @@ dependencies = [
 
 [[package]]
 name = "cpal"
-version = "0.16.0"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
+checksum = "d8942da362c0f0d895d7cac616263f2f9424edc5687364dfd1d25ef7eba506d7"
 dependencies = [
  "alsa",
  "coreaudio-rs",
@@ -341,13 +466,26 @@ dependencies = [
  "ndk-context",
  "num-derive",
  "num-traits",
+ "objc2",
  "objc2-audio-toolbox",
+ "objc2-avf-audio",
  "objc2-core-audio",
  "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "windows",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -361,15 +499,17 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "crossterm_winapi",
+ "derive_more",
+ "document-features",
  "mio",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -385,10 +525,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.20.11"
+name = "crypto-common"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -396,27 +556,26 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -424,6 +583,53 @@ name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -448,11 +654,11 @@ dependencies = [
 
 [[package]]
 name = "dispatch2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
 ]
 
@@ -464,8 +670,23 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -499,16 +720,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
 name = "fast-srgb8"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
-
-[[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -520,16 +754,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "find-msvc-tools"
-version = "0.1.5"
+name = "filedescriptor"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.1.5"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -548,6 +805,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "fontdue"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -556,21 +819,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "ttf-parser",
 ]
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -582,10 +830,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
+name = "fs_extra"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -593,33 +847,33 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -627,19 +881,30 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.16"
+name = "generic-array"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -649,9 +914,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -662,9 +942,9 @@ checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -687,7 +967,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -695,12 +975,23 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -780,31 +1071,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
  "base64",
  "bytes",
  "futures-channel",
- "futures-core",
  "futures-util",
  "http",
  "http-body",
@@ -903,6 +1177,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -939,17 +1219,45 @@ dependencies = [
  "byteorder",
  "color_quant",
  "num-traits",
- "png",
+ "png 0.17.16",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.12.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
+checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -963,28 +1271,28 @@ dependencies = [
 
 [[package]]
 name = "instability"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
  "darling",
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f867b9d1d896b67beb18518eda36fdb77a32ea590de864f1325b294a6d14397"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
 dependencies = [
  "memchr",
  "serde",
@@ -998,18 +1306,18 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jni"
@@ -1034,48 +1342,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "js-sys"
-version = "0.3.83"
+name = "jobserver"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.178"
+name = "kasuari"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.183"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags 2.10.0",
  "libc",
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1094,18 +1449,34 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
 ]
 
 [[package]]
 name = "mach2"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -1118,7 +1489,7 @@ checksum = "d2befbae373456143ef55aa93a73594d080adfb111dc32ec96a1123a3e4ff4ae"
 dependencies = [
  "fontdue",
  "glam",
- "image",
+ "image 0.24.9",
  "macroquad_macro",
  "miniquad",
  "quad-rand",
@@ -1141,15 +1512,36 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniquad"
@@ -1186,20 +1578,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.14"
+name = "moxcms"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
+ "num-traits",
+ "pxfm",
 ]
 
 [[package]]
@@ -1208,7 +1593,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "jni-sys",
  "log",
  "ndk-sys 0.6.0+11769913",
@@ -1238,6 +1623,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,6 +1655,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
 name = "num-derive"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1254,7 +1668,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1268,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
 dependencies = [
  "num_enum_derive",
  "rustversion",
@@ -1278,14 +1692,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1299,9 +1722,9 @@ dependencies = [
 
 [[package]]
 name = "objc2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
 dependencies = [
  "objc2-encode",
 ]
@@ -1312,12 +1735,22 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
  "objc2",
  "objc2-core-audio",
  "objc2-core-audio-types",
  "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "objc2",
  "objc2-foundation",
 ]
 
@@ -1331,6 +1764,7 @@ dependencies = [
  "objc2",
  "objc2-core-audio-types",
  "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -1339,7 +1773,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "objc2",
 ]
 
@@ -1349,8 +1783,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 
@@ -1366,14 +1802,18 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
+ "bitflags 2.11.0",
+ "block2",
+ "libc",
  "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -1382,54 +1822,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "palette"
@@ -1452,7 +1863,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1479,16 +1890,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "phf"
@@ -1501,13 +1949,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1520,7 +1978,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1534,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -1564,10 +2022,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "pollster"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -1579,22 +2056,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
+name = "powerfmt"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "pxfm"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
 
 [[package]]
 name = "quad-rand"
@@ -1603,10 +2111,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
-name = "quote"
-version = "1.0.42"
+name = "quick-error"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1618,12 +2188,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1633,24 +2229,97 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
-name = "ratatui"
-version = "0.29.0"
+name = "rand_core"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "bitflags 2.10.0",
- "cassowary",
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.0",
  "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
  "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
+ "line-clipping",
+ "ratatui-core",
  "strum",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1659,7 +2328,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1668,16 +2337,45 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.12.25"
+name = "regex"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eff9328d40131d43bd911d42d79eb6a47312002a4daefc9e37f17e74a7701a"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64",
  "bytes",
@@ -1691,21 +2389,21 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -1723,44 +2421,47 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "rustc-hash"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "bitflags 2.10.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "1.1.2"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.35"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -1769,20 +2470,61 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.13.1"
+name = "rustls-native-certs"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
  "zeroize",
 ]
 
 [[package]]
-name = "rustls-webpki"
-version = "0.103.8"
+name = "rustls-platform-verifier"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1796,9 +2538,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.20"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -1811,9 +2553,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -1826,12 +2568,12 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
-version = "2.11.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.11.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1839,13 +2581,19 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -1874,41 +2622,40 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24345aa0fe688594e73770a5f6d1b216508b4f93484c0026d521acd30134392"
+checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
+name = "sha2"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1940,10 +2687,11 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.7"
+version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
+ "errno",
  "libc",
 ]
 
@@ -1955,15 +2703,15 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "siphasher"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
@@ -1973,12 +2721,12 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2001,24 +2749,23 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2029,9 +2776,20 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2055,17 +2813,17 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
- "core-foundation",
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2080,16 +2838,66 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.23.0"
+name = "terminfo"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
 dependencies = [
- "fastrand",
- "getrandom 0.3.4",
- "once_cell",
- "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
 ]
 
 [[package]]
@@ -2103,11 +2911,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2118,19 +2926,40 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -2143,10 +2972,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.48.0"
+name = "tinyvec"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
@@ -2154,16 +2998,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -2178,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2191,9 +3025,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.8"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0dc8b1fb61449e27716ec0e1bdf0f6b8f3e8f6b05391e8497b8b6d7804ea6d8"
+checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2206,18 +3040,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.3"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2cdb639ebbc97961c51720f858597f7f24c4fc295327923af55b74c3c724533"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.9"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2227,24 +3061,24 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.4"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.4"
+version = "1.0.6+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
+checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -2261,7 +3095,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -2287,9 +3121,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.43"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -2297,9 +3131,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
 ]
@@ -2317,10 +3151,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
-name = "unicode-ident"
-version = "1.0.22"
+name = "typenum"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2330,26 +3176,26 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.0"
+name = "unicode-xid"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2359,9 +3205,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.7"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2382,10 +3228,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
+name = "uuid"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "walkdir"
@@ -2414,18 +3281,27 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.1+wasi-0.2.4"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2436,11 +3312,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.56"
+version = "0.4.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
+checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
 dependencies = [
  "cfg-if",
+ "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -2449,9 +3326,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2459,34 +3336,159 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.83"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -2522,22 +3524,69 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.54.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
  "windows-core",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.54.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2547,23 +3596,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
 name = "windows-registry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2598,15 +3648,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2675,6 +3716,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -2817,18 +3867,100 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.46.0"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -2855,8 +3987,28 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2578b716f8a7a858b7f02d5bd870c14bf4ddbbcf3a4c05414ba6503640505e3"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e6cc098ea4d3bd6246687de65af3f920c430e236bee1e3bf2e441463f08a02f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2876,7 +4028,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2916,5 +4068,26 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec5f41c76397b7da451efd19915684f727d7e1d516384ca6bd0ec43ec94de23c"
+dependencies = [
+ "zune-core",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,8 +116,10 @@ dependencies = [
  "cpal",
  "dasp_sample",
  "dirs",
+ "macroquad",
  "num-complex",
  "palette",
+ "pollster",
  "ratatui",
  "reqwest",
  "serde",
@@ -156,6 +164,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
+name = "bytemuck"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.48"
+version = "1.2.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
+checksum = "90583009037521a116abf44494efecd645ba48b6622457080f080b85544e2215"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -237,6 +257,12 @@ name = "clap_lex"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -322,6 +348,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -476,10 +511,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "flate2"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2152dbcb980c05735e2a651d96011320a949eb31a0c8b38b72645ce97dec676"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -492,6 +546,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "fontdue"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e57e16b3fe8ff4364c0661fdaac543fb38b29ea9bc9c2f45612d90adf931d2b"
+dependencies = [
+ "hashbrown 0.15.5",
+ "ttf-parser",
+]
 
 [[package]]
 name = "foreign-types"
@@ -589,6 +653,12 @@ dependencies = [
  "r-efi",
  "wasip2",
 ]
+
+[[package]]
+name = "glam"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e05e7e6723e3455f4818c7b26e855439f7546cf617ef669d1adedb8669e5cb9"
 
 [[package]]
 name = "h2"
@@ -860,6 +930,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1111,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "macroquad"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2befbae373456143ef55aa93a73594d080adfb111dc32ec96a1123a3e4ff4ae"
+dependencies = [
+ "fontdue",
+ "glam",
+ "image",
+ "macroquad_macro",
+ "miniquad",
+ "quad-rand",
+]
+
+[[package]]
+name = "macroquad_macro"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b1d96218903768c1ce078b657c0d5965465c95a60d2682fd97443c9d2483dd"
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1150,28 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniquad"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fb3e758e46dbc45716a8a49ca9edc54b15bcca826277e80b1f690708f67f9e3"
+dependencies = [
+ "libc",
+ "ndk-sys 0.2.2",
+ "objc-rs",
+ "winapi",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -1077,7 +1211,7 @@ dependencies = [
  "bitflags 2.10.0",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 1.0.69",
 ]
@@ -1087,6 +1221,12 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121"
 
 [[package]]
 name = "ndk-sys"
@@ -1146,6 +1286,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "objc-rs"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a1e7069a2525126bf12a9f1f7916835fafade384fb27cabf698e745e2a1eb8"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -1402,6 +1551,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,6 +1595,12 @@ checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "quad-rand"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a651516ddc9168ebd67b24afd085a718be02f8858fe406591b013d101ce2f40"
 
 [[package]]
 name = "quote"
@@ -1774,6 +1948,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,9 +2215,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.23.8"
+version = "0.23.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9b7ac41d92f2d2803f233e297127bac397df7b337e0460a1cc39d6c006dee4"
+checksum = "5d7cbc3b4b49633d57a0509303158ca50de80ae32c265093b24c414705807832"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2129,6 +2309,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ttf-parser"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,30 +3,6 @@
 version = 4
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
-
-[[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -39,7 +15,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
 dependencies = [
  "alsa-sys",
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "libc",
 ]
@@ -56,9 +32,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -71,44 +47,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
- "once_cell",
- "windows-sys 0.59.0",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "approx"
@@ -145,48 +121,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "bindgen"
-version = "0.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f49d8fed880d473ea71efb9bf597651e77201bdd4893efe54c9e5d65ae04ce6f"
-dependencies = [
- "bitflags 2.8.0",
- "cexpr",
- "clang-sys",
- "itertools",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn",
-]
 
 [[package]]
 name = "bitflags"
@@ -196,15 +139,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.8.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bumpalo"
-version = "3.17.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "by_address"
@@ -214,9 +157,9 @@ checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
 
 [[package]]
 name = "cassowary"
@@ -226,21 +169,20 @@ checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.12"
+version = "1.2.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755717a7de9ec452bf7f3f1a3099085deabd7f2962b861dae91ecd7a365903d2"
+checksum = "c481bdbf0ed3b892f6f806287d72acd515b352a4ec27a208489b8c1bc839633a"
 dependencies = [
- "jobserver",
- "libc",
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -251,36 +193,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.28"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+checksum = "c9e340e012a1bf4935f5282ed1436d1489548e8f72308207ea5df0e23d2d03f8"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -288,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.27"
+version = "4.5.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+checksum = "d76b5d13eaa18c901fd2f7fca939fefe3a0727a953561fefdf3b2922b8569d00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -300,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -312,15 +234,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -364,32 +286,25 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.11.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+checksum = "1aae284fbaf7d27aa0e292f7677dfbe26503b0d555026f702940805a630eac17"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation-sys",
- "coreaudio-sys",
-]
-
-[[package]]
-name = "coreaudio-sys"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce857aa0b77d77287acc1ac3e37a05a8c95a2af3647d23b15f263bdaeb7562b"
-dependencies = [
- "bindgen",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
 ]
 
 [[package]]
 name = "cpal"
-version = "0.15.3"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+checksum = "cbd307f43cc2a697e2d1f8bc7a1d824b5269e052209e28883e5bc04d095aaa3f"
 dependencies = [
  "alsa",
- "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni",
@@ -398,7 +313,11 @@ dependencies = [
  "mach2",
  "ndk",
  "ndk-context",
- "oboe",
+ "num-derive",
+ "num-traits",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -411,11 +330,11 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -432,9 +351,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -442,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -456,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
@@ -473,23 +392,33 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
 ]
 
 [[package]]
@@ -505,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encoding_rs"
@@ -520,18 +449,18 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -547,6 +476,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -554,9 +489,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -575,9 +510,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -634,44 +569,32 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
-name = "glob"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -688,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -711,12 +634,11 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
- "fnv",
  "itoa",
 ]
 
@@ -732,12 +654,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -745,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d708df4e7140240a16cd6ab0ab65c972d7433ab77819ea693fde9c43811e2a"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "hyper"
@@ -773,11 +695,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -822,7 +743,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -832,21 +753,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -856,96 +778,58 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -956,9 +840,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -967,9 +851,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -987,15 +871,18 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "instability"
-version = "0.3.7"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+checksum = "6778b0196eefee7df739db78758e5cf9b37412268bfa5650bfeed028aed20d9c"
 dependencies = [
  "darling",
  "indoc",
@@ -1022,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -1037,9 +924,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -1052,7 +939,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -1064,19 +951,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
-name = "jobserver"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1089,22 +967,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "libc",
 ]
 
@@ -1115,26 +983,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "litemap"
-version = "0.7.4"
+name = "linux-raw-sys"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litemap"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
@@ -1142,23 +1015,23 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
 name = "mach2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mime"
@@ -1167,37 +1040,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "wasi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dab59f8e050d5df8e4dd87d9206fb6f65a483e20ac9fda365ade4fab353196c"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -1212,16 +1070,16 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "jni-sys",
  "log",
  "ndk-sys",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1232,21 +1090,11 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.5.0+25.2.9519653"
+version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1280,18 +1128,19 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "b1207a7e20ad57b847bbddc6776b968420d38292bbfe2089accff5e19e82454c"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1300,50 +1149,96 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.36.7"
+name = "objc2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "b7c2599ce0ec54857b29ce62166b0ed9b4f6f1a70ccc9a71165b6154caca8c05"
 dependencies = [
- "memchr",
+ "objc2-encode",
 ]
 
 [[package]]
-name = "oboe"
-version = "0.6.1"
+name = "objc2-audio-toolbox"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+checksum = "6948501a91121d6399b79abaa33a8aa4ea7857fe019f341b8c23ad6e81b79b08"
 dependencies = [
- "jni",
- "ndk",
- "ndk-context",
- "num-derive",
- "num-traits",
- "oboe-sys",
+ "bitflags 2.10.0",
+ "libc",
+ "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
-name = "oboe-sys"
-version = "0.6.1"
+name = "objc2-core-audio"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
 dependencies = [
- "cc",
+ "dispatch2",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.10.0",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.10.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.70"
+version = "0.10.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfb4e166a8bb8c9b55c500bc2308550148ece889be90f609377e58140f42c6"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1371,9 +1266,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.105"
+version = "0.9.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b22d5b84be05a8d6947c7cb71f7c849aa0f112acd4bf51c2a7c1c988ac0a9dc"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
 dependencies = [
  "cc",
  "libc",
@@ -1413,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1423,15 +1318,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
@@ -1442,9 +1337,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
@@ -1502,36 +1397,51 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1554,7 +1464,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -1571,52 +1481,23 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
- "thiserror",
+ "thiserror 2.0.17",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
@@ -1662,30 +1543,17 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -1693,18 +1561,31 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
-name = "rustls"
-version = "0.23.22"
+name = "rustix"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags 2.10.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1715,15 +1596,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "708c0f9d5f54ba0272468c1d306a52c495b31fa155e91bc25371e6df7996908c"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1732,15 +1616,15 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.19"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -1753,11 +1637,11 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
+checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1772,7 +1656,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1781,9 +1665,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.14.0"
+version = "2.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
+checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1861,9 +1745,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -1871,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
@@ -1882,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "7664a098b8e616bdfcc2dc0e9ac44eb231eedf41db4e9fe95d8d32ec728dedad"
 dependencies = [
  "libc",
 ]
@@ -1897,28 +1781,15 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
-
-[[package]]
-name = "socket2"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
@@ -1931,16 +1802,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -1984,9 +1849,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.111"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2004,9 +1869,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2019,7 +1884,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -2036,16 +1901,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.16.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.4",
  "once_cell",
- "rustix",
- "windows-sys 0.59.0",
+ "rustix 1.1.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2054,7 +1918,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+dependencies = [
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -2069,10 +1942,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinystr"
-version = "0.7.6"
+name = "thiserror-impl"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2080,17 +1964,16 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
 dependencies = [
- "backtrace",
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.5.8",
- "windows-sys 0.52.0",
+ "socket2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2105,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -2115,9 +1998,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2135,17 +2018,11 @@ dependencies = [
  "indexmap",
  "serde_core",
  "serde_spanned",
- "toml_datetime 0.7.3",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
  "winnow",
 ]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_datetime"
@@ -2158,12 +2035,13 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.23"
+version = "0.23.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02a8b472d1a3d7c18e2d61a489aee3453fd9031c33e4f55bd533f4a7adca1bee"
+checksum = "5a9b7ac41d92f2d2803f233e297127bac397df7b337e0460a1cc39d6c006dee4"
 dependencies = [
  "indexmap",
- "toml_datetime 0.6.8",
+ "toml_datetime",
+ "toml_parser",
  "winnow",
 ]
 
@@ -2203,7 +2081,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
 dependencies = [
- "bitflags 2.8.0",
+ "bitflags 2.10.0",
  "bytes",
  "futures-util",
  "http",
@@ -2229,9 +2107,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "pin-project-lite",
  "tracing-core",
@@ -2239,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
 ]
@@ -2254,9 +2132,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.16"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2295,20 +2173,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -2349,50 +2222,37 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen-rt",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "836d9622d604feee9e5de25ac10e3ea5f2d65b41eac0d9ce72eb5deae707ce7c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2403,9 +2263,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2413,31 +2273,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
  "syn",
- "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2461,11 +2321,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2549,15 +2409,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2584,6 +2435,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2596,21 +2456,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2654,12 +2499,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2678,12 +2517,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2699,12 +2532,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2738,12 +2565,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2759,12 +2580,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2786,12 +2601,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2807,12 +2616,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2836,33 +2639,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.33.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
-dependencies = [
- "bitflags 2.8.0",
-]
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -2870,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2882,18 +2675,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2903,15 +2696,26 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2920,9 +2724,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "audioleaf"
-version = "3.2.0"
+version = "3.3.0"
 edition = "2021"
 authors = ["Antoni Zasada", "weekendsuperhero"]
 description = "Manage your Nanoleaf devices (Canvas, Shapes, Elements, Light Panels) and visualize music straight from the terminal"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,34 +1,40 @@
 [package]
 name = "audioleaf"
-version = "3.3.0"
-edition = "2021"
+version = "3.5.0"
+edition = "2024"
 authors = ["Antoni Zasada", "weekendsuperhero"]
 description = "Manage your Nanoleaf devices (Canvas, Shapes, Elements, Light Panels) and visualize music straight from the terminal"
-keywords = ["nanoleaf", "audio", "music", "visualizer"]
+keywords = ["audio", "music", "nanoleaf", "visualizer"]
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/weekendsuperhero/audioleaf"
+repository = "https://github.com/weekendsuperhero-io/audioleaf"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.86"
-clap = { version = "4.5.16", features = ["derive"] }
-cpal = "0.16.0"
+anyhow = "1.0.102"
+clap = { version = "4.6.0", features = ["derive"] }
+auto-palette = "0.9"
+cpal = "0.17.3"
 dasp_sample = "0.11.0"
 dirs = "6.0.0"
 macroquad = "0.4"
+image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 num-complex = "0.4.6"
 palette = "0.7.6"
 pollster = "0.4"
-ratatui = "0.29.0"
-reqwest = { version = "0.12.24", features = ["blocking", "json"] }
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
-toml = "0.9.8"
+ratatui = "0.30"
+reqwest = { version = "0.13", features = ["blocking", "json"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+toml = "1"
 
-[profile.release]
-panic = "abort"
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = ["NSString", "NSData"] }
 
 [profile.dev]
+panic = "abort"
+
+[profile.release]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,10 @@ clap = { version = "4.5.16", features = ["derive"] }
 cpal = "0.16.0"
 dasp_sample = "0.11.0"
 dirs = "6.0.0"
+macroquad = "0.4"
 num-complex = "0.4.6"
 palette = "0.7.6"
+pollster = "0.4"
 ratatui = "0.29.0"
 reqwest = { version = "0.12.24", features = ["blocking", "json"] }
 serde = { version = "1.0.228", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ repository = "https://github.com/weekendsuperhero/audioleaf"
 [dependencies]
 anyhow = "1.0.86"
 clap = { version = "4.5.16", features = ["derive"] }
-cpal = "0.15.3"
+cpal = "0.16.0"
 dasp_sample = "0.11.0"
-dirs = "5.0.1"
+dirs = "6.0.0"
 num-complex = "0.4.6"
 palette = "0.7.6"
 ratatui = "0.29.0"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: build universal clean
+
+build:
+	cargo build --release
+
+universal:
+	rustup target add x86_64-apple-darwin aarch64-apple-darwin
+	cargo build --release --target x86_64-apple-darwin
+	cargo build --release --target aarch64-apple-darwin
+	lipo -create \
+		target/x86_64-apple-darwin/release/audioleaf \
+		target/aarch64-apple-darwin/release/audioleaf \
+		-output target/release/audioleaf-universal
+
+clean:
+	cargo clean

--- a/src/app.rs
+++ b/src/app.rs
@@ -93,6 +93,25 @@ pub struct App {
 }
 
 impl App {
+    /// Constructs a new `App` for TUI-based Nanoleaf effect selection and audio visualizer.
+    ///
+    /// Initializes:
+    /// - Effect list from device API, selects current effect if running.
+    /// - Visualizer with audio stream, UDP, config params, starts processing thread via `init()`.
+    /// - State to EffectList view, running effects mode.
+    /// - Palette names from predefined for switching.
+    /// - Colorful names from TUI config.
+    /// - Fetches device global orientation for panel sorting.
+    ///
+    /// # Arguments
+    ///
+    /// * `nl_device` - Connected Nanoleaf device.
+    /// * `tui_config` - UI settings like colorful effect names.
+    /// * `visualizer_config` - Audio/viz params like gain, hues, sorting.
+    ///
+    /// # Errors
+    ///
+    /// From device API, visualizer new/init, or effect list fetch.
     pub fn new(
         nl_device: NlDevice,
         tui_config: TuiConfig,
@@ -166,6 +185,21 @@ impl App {
         })
     }
 
+    /// Executes the main TUI application loop.
+    ///
+    /// Creates event handler for key/tick events.
+    /// Loop: draw current view, receive event, map to AppMsg, update app state.
+    /// Breaks when state=Done (quit).
+    /// On exit, sends End msg to visualizer to stop audio/UDP thread.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - Mutable app state.
+    /// * `terminal` - Ratatui terminal for rendering frames.
+    ///
+    /// # Errors
+    ///
+    /// From event recv, update logic, or draw.
     pub fn run(&mut self, terminal: &mut Terminal<impl Backend>) -> Result<()> {
         let event_handler = event_handler::EventHandler::new();
         loop {
@@ -181,6 +215,24 @@ impl App {
         Ok(())
     }
 
+    /// Converts raw terminal events to `AppMsg` for state updates.
+    ///
+    /// Ignores ticks (NoOp).
+    /// Maps KeyEvent codes to actions:
+    /// - ESC/Q: Quit
+    /// - Enter: Play selected effect in list view
+    /// - Up/Down/j/k: Scroll list
+    /// - g/G: Scroll top/bottom
+    /// - V: Toggle EffectList <-> Visualizer view
+    /// - ?: Toggle help screen
+    /// - +/-=_ : Adjust visualizer gain by ±0.05
+    /// - 0-9: Switch to numbered palette
+    /// - a/A: Toggle primary axis X/Y
+    /// - p/P: Toggle primary sort Asc/Desc
+    /// - s/S: Toggle secondary sort Asc/Desc
+    /// - Defaults to NoOp for unhandled.
+    ///
+    /// View-specific logic, e.g., scroll only in EffectList.
     fn event_to_msg(&self, event: Event) -> AppMsg {
         match event {
             Event::Tick => AppMsg::NoOp,
@@ -335,6 +387,22 @@ impl App {
         }
     }
 
+    /// Applies an `AppMsg` to update application state, views, or external components.
+    ///
+    /// Match on msg type:
+    /// - NoOp/Quit: Idle or set Done state.
+    /// - Scroll: Adjust effect list selection and scrollbar position.
+    /// - View change: Switch views, pause/resume visualizer or effects mode, enable UDP if needed.
+    /// - PlayEffect: Calls device.play_effect by selected name.
+    /// - ChangeGain/Palette: Send SetGain/SetPalette to visualizer tx.
+    /// - Toggles (Axis/Sorts): Flip enum, send SetSorting with current params to visualizer.
+    ///
+    /// Syncs list state with scrollbar for rendering.
+    /// Ensures state transitions (e.g., resume viz only if switching to it).
+    ///
+    /// # Errors
+    ///
+    /// From device API calls or visualizer msg send.
     fn update(&mut self, msg: AppMsg) -> Result<()> {
         match msg {
             AppMsg::NoOp => Ok(()),
@@ -467,6 +535,14 @@ impl App {
         }
     }
 
+    /// Renders the active view (effect list, visualizer, or help) into the terminal frame.
+    ///
+    /// Creates bordered main block with device name in magenta left title, right-aligned "? for help".
+    /// Dispatches to view-specific rendering:
+    /// - `EffectList`: Stateful list of NlEffect items, optional colorful char styling via palette,
+    ///   highlight with >> symbol, synced scrollbar with padding.
+    /// - Other views (Visualizer/HelpScreen): Implementation details for spectrum display or key bindings.
+    /// - Updates scrollbar state post-render if needed.
     fn render_view(&mut self, frame: &mut Frame) {
         let main_block = Block::new()
             .borders(Borders::ALL)

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use crate::event_handler::{self, Event};
 use crate::utils;
 use crate::visualizer::VisualizerMsg;
 use crate::{
-    config::{TuiConfig, VisualizerConfig},
+    config::{Axis, Sort, TuiConfig, VisualizerConfig},
     nanoleaf::{NlDevice, NlEffect},
     visualizer,
 };
@@ -50,6 +50,10 @@ enum AppMsg {
     ScrollToBottom,
     ScrollToTop,
     ChangeGain(f32),
+    ChangePalette(usize),
+    ToggleAxis,
+    TogglePrimarySort,
+    ToggleSecondarySort,
 }
 
 #[derive(Debug)]
@@ -69,6 +73,12 @@ struct EffectList {
 struct Visualizer {
     tx: mpsc::Sender<VisualizerMsg>,
     gain: f32,
+    current_palette_index: usize,
+    palette_names: Vec<String>,
+    primary_axis: Axis,
+    sort_primary: Sort,
+    sort_secondary: Sort,
+    global_orientation: u16,
 }
 
 #[derive(Debug)]
@@ -113,8 +123,34 @@ impl App {
             .default_gain
             .unwrap_or(constants::DEFAULT_GAIN);
         eprintln!("INFO: Starting with gain: {}", gain);
+
+        // Get global orientation
+        let global_orientation = nl_device
+            .get_global_orientation()
+            .ok()
+            .and_then(|o| o["value"].as_u64())
+            .unwrap_or(0) as u16;
+
+        let primary_axis = visualizer_config.primary_axis.unwrap_or_default();
+        let sort_primary = visualizer_config.sort_primary.unwrap_or_default();
+        let sort_secondary = visualizer_config.sort_secondary.unwrap_or_default();
+
         let tx = visualizer::Visualizer::new(visualizer_config, audio_stream, &nl_device)?.init();
-        let visualizer = Visualizer { tx, gain };
+
+        // Initialize palette list
+        let mut palette_names = crate::palettes::get_palette_names();
+        palette_names.sort();
+
+        let visualizer = Visualizer {
+            tx,
+            gain,
+            current_palette_index: 0,
+            palette_names,
+            primary_axis,
+            sort_primary,
+            sort_secondary,
+            global_orientation,
+        };
         let display_colors = tui_config
             .colorful_effect_names
             .unwrap_or(constants::DEFAULT_COLORFUL_EFFECT_NAMES);
@@ -199,6 +235,97 @@ impl App {
                 KeyCode::Char('=') | KeyCode::Char('+') => {
                     if let AppView::Visualizer = self.view {
                         AppMsg::ChangeGain(0.05)
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('1') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ChangePalette(0)
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('2') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ChangePalette(1)
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('3') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ChangePalette(2)
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('4') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ChangePalette(3)
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('5') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ChangePalette(4)
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('6') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ChangePalette(5)
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('7') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ChangePalette(6)
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('8') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ChangePalette(7)
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('9') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ChangePalette(8)
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('0') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ChangePalette(9)
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('a') | KeyCode::Char('A') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ToggleAxis
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('p') | KeyCode::Char('P') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::TogglePrimarySort
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('s') | KeyCode::Char('S') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ToggleSecondarySort
                     } else {
                         AppMsg::NoOp
                     }
@@ -288,6 +415,55 @@ impl App {
                     .send(VisualizerMsg::SetGain(self.visualizer.gain))?;
                 Ok(())
             }
+            AppMsg::ChangePalette(index) => {
+                if index < self.visualizer.palette_names.len() {
+                    let palette_name = &self.visualizer.palette_names[index];
+                    if let Some(hues) = crate::palettes::get_palette(palette_name) {
+                        self.visualizer.current_palette_index = index;
+                        self.visualizer.tx.send(VisualizerMsg::SetPalette(hues))?;
+                    }
+                }
+                Ok(())
+            }
+            AppMsg::ToggleAxis => {
+                self.visualizer.primary_axis = match self.visualizer.primary_axis {
+                    Axis::X => Axis::Y,
+                    Axis::Y => Axis::X,
+                };
+                self.visualizer.tx.send(VisualizerMsg::SetSorting {
+                    primary_axis: self.visualizer.primary_axis,
+                    sort_primary: self.visualizer.sort_primary,
+                    sort_secondary: self.visualizer.sort_secondary,
+                    global_orientation: self.visualizer.global_orientation,
+                })?;
+                Ok(())
+            }
+            AppMsg::TogglePrimarySort => {
+                self.visualizer.sort_primary = match self.visualizer.sort_primary {
+                    Sort::Asc => Sort::Desc,
+                    Sort::Desc => Sort::Asc,
+                };
+                self.visualizer.tx.send(VisualizerMsg::SetSorting {
+                    primary_axis: self.visualizer.primary_axis,
+                    sort_primary: self.visualizer.sort_primary,
+                    sort_secondary: self.visualizer.sort_secondary,
+                    global_orientation: self.visualizer.global_orientation,
+                })?;
+                Ok(())
+            }
+            AppMsg::ToggleSecondarySort => {
+                self.visualizer.sort_secondary = match self.visualizer.sort_secondary {
+                    Sort::Asc => Sort::Desc,
+                    Sort::Desc => Sort::Asc,
+                };
+                self.visualizer.tx.send(VisualizerMsg::SetSorting {
+                    primary_axis: self.visualizer.primary_axis,
+                    sort_primary: self.visualizer.sort_primary,
+                    sort_secondary: self.visualizer.sort_secondary,
+                    global_orientation: self.visualizer.global_orientation,
+                })?;
+                Ok(())
+            }
         }
     }
 
@@ -343,16 +519,71 @@ impl App {
                 );
             }
             AppView::Visualizer => {
-                frame.render_widget(
-                    Paragraph::new(vec![
-                        Line::from("Music Visualizer".bold().cyan()),
+                let current_palette = if self.visualizer.current_palette_index
+                    < self.visualizer.palette_names.len()
+                {
+                    &self.visualizer.palette_names[self.visualizer.current_palette_index]
+                } else {
+                    "Unknown"
+                };
+
+                let axis_str = match self.visualizer.primary_axis {
+                    Axis::X => "X",
+                    Axis::Y => "Y",
+                };
+                let primary_str = match self.visualizer.sort_primary {
+                    Sort::Asc => "Asc",
+                    Sort::Desc => "Desc",
+                };
+                let secondary_str = match self.visualizer.sort_secondary {
+                    Sort::Asc => "Asc",
+                    Sort::Desc => "Desc",
+                };
+
+                let mut lines = vec![
+                    Line::from("Music Visualizer".bold().cyan()),
+                    Line::from(""),
+                    Line::from(vec![
+                        "Amplitude gain: ".into(),
+                        format!("{:.2}", self.visualizer.gain).blue(),
+                    ]),
+                    Line::from(vec!["Current palette: ".into(), current_palette.green()]),
+                    Line::from(""),
+                    Line::from("Panel Sorting:".bold()),
+                    Line::from(vec![
+                        "  Primary Axis [A]: ".into(),
+                        axis_str.yellow(),
+                        "  |  Primary [P]: ".into(),
+                        primary_str.yellow(),
+                        "  |  Secondary [S]: ".into(),
+                        secondary_str.yellow(),
+                    ]),
+                    Line::from(""),
+                    Line::from("Available Palettes (press number to switch):".bold()),
+                ];
+
+                for (i, palette_name) in self.visualizer.palette_names.iter().enumerate().take(10) {
+                    let key = if i == 9 {
+                        "0".to_string()
+                    } else {
+                        (i + 1).to_string()
+                    };
+                    let is_current = i == self.visualizer.current_palette_index;
+                    let line = if is_current {
                         Line::from(vec![
-                            "Amplitude gain: ".into(),
-                            format!("{:.2}", self.visualizer.gain).blue(),
-                        ]),
-                    ])
-                    .block(main_block)
-                    .centered(),
+                            key.bold().yellow(),
+                            " - ".into(),
+                            palette_name.as_str().green().bold(),
+                            " ◀".green(),
+                        ])
+                    } else {
+                        Line::from(vec![key.bold(), " - ".into(), palette_name.as_str().into()])
+                    };
+                    lines.push(line);
+                }
+
+                frame.render_widget(
+                    Paragraph::new(lines).block(main_block).centered(),
                     frame.area(),
                 );
             }
@@ -367,7 +598,11 @@ impl App {
                         Line::from(vec!["Enter".bold(), " - play selected effect".into()]),
                         Line::from(vec!["V".bold(), " - toggle music visualizer mode".into()]),
                         Line::from(vec!["-/+".bold(), " - decrease/increase gain (in visualizer mode)".into()]),
-                        Line::from(vec!["(note that this doesn't affect your music volume, only the visuals are amplified)".italic()]),
+                        Line::from(vec!["1-9, 0".bold(), " - switch color palette (in visualizer mode)".into()]),
+                        Line::from(vec!["A".bold(), " - toggle primary axis X/Y (in visualizer mode)".into()]),
+                        Line::from(vec!["P".bold(), " - toggle primary sort Asc/Desc (in visualizer mode)".into()]),
+                        Line::from(vec!["S".bold(), " - toggle secondary sort Asc/Desc (in visualizer mode)".into()]),
+                        Line::from(vec!["(note that gain doesn't affect your music volume, only the visuals are amplified)".italic()]),
                     ])
                     .block(main_block)
                     .centered(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -744,8 +744,7 @@ impl App {
                     } else if self.visualizer.current_palette_index
                         < self.visualizer.palette_names.len()
                     {
-                        self.visualizer.palette_names[self.visualizer.current_palette_index]
-                            .clone()
+                        self.visualizer.palette_names[self.visualizer.current_palette_index].clone()
                     } else {
                         "Unknown".to_string()
                     };

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,24 +4,29 @@ use crate::event_handler::{self, Event};
 use crate::utils;
 use crate::visualizer::VisualizerMsg;
 use crate::{
-    config::{Axis, Sort, TuiConfig, VisualizerConfig},
+    config::{Axis, Effect, Sort, TuiConfig, VisualizerConfig},
     nanoleaf::{NlDevice, NlEffect},
     visualizer,
 };
 use anyhow::Result;
 use ratatui::{
+    Frame, Terminal,
     crossterm::event::KeyCode,
     layout::Margin,
     prelude::Backend,
-    style::{Style, Stylize},
-    text::Line,
+    style::{Color, Style, Stylize},
+    text::{Line, Span},
     widgets::{
         Block, Borders, HighlightSpacing, List, ListDirection, ListItem, ListState, Paragraph,
         Scrollbar, ScrollbarOrientation, ScrollbarState,
     },
-    Frame, Terminal,
 };
-use std::sync::mpsc;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+    mpsc,
+};
+use std::time::Duration;
 
 #[derive(Debug, Default)]
 enum AppState {
@@ -51,9 +56,21 @@ enum AppMsg {
     ScrollToTop,
     ChangeGain(f32),
     ChangePalette(usize),
+    CycleEffect,
+    ResetPanels,
+    UseAlbumArtPalette,
     ToggleAxis,
     TogglePrimarySort,
     ToggleSecondarySort,
+}
+
+/// Display state shared between the main thread and the album art watcher thread.
+#[derive(Debug)]
+struct VizState {
+    /// The RGB colors currently driving the visualizer palette.
+    colors: Vec<[u8; 3]>,
+    /// Set when album art mode is active; cleared when switching to a named palette.
+    track_title: Option<String>,
 }
 
 #[derive(Debug)]
@@ -75,6 +92,9 @@ struct Visualizer {
     gain: f32,
     current_palette_index: usize,
     palette_names: Vec<String>,
+    viz_state: Arc<Mutex<VizState>>,
+    album_art_stop: Option<Arc<AtomicBool>>,
+    effect: Effect,
     primary_axis: Axis,
     sort_primary: Sort,
     sort_secondary: Sort,
@@ -153,18 +173,31 @@ impl App {
         let primary_axis = visualizer_config.primary_axis.unwrap_or_default();
         let sort_primary = visualizer_config.sort_primary.unwrap_or_default();
         let sort_secondary = visualizer_config.sort_secondary.unwrap_or_default();
+        let effect = visualizer_config.effect.unwrap_or_default();
+
+        let initial_colors = visualizer_config
+            .colors
+            .clone()
+            .unwrap_or_else(|| Vec::from(constants::DEFAULT_COLORS));
 
         let tx = visualizer::Visualizer::new(visualizer_config, audio_stream, &nl_device)?.init();
 
         // Initialize palette list
         let mut palette_names = crate::palettes::get_palette_names();
         palette_names.sort();
+        let viz_state = Arc::new(Mutex::new(VizState {
+            colors: initial_colors,
+            track_title: None,
+        }));
 
         let visualizer = Visualizer {
             tx,
             gain,
             current_palette_index: 0,
             palette_names,
+            viz_state,
+            album_art_stop: None,
+            effect,
             primary_axis,
             sort_primary,
             sort_secondary,
@@ -200,7 +233,10 @@ impl App {
     /// # Errors
     ///
     /// From event recv, update logic, or draw.
-    pub fn run(&mut self, terminal: &mut Terminal<impl Backend>) -> Result<()> {
+    pub fn run<B: Backend>(&mut self, terminal: &mut Terminal<B>) -> Result<()>
+    where
+        B::Error: Send + Sync + 'static,
+    {
         let event_handler = event_handler::EventHandler::new();
         loop {
             terminal.draw(|frame| self.render_view(frame))?;
@@ -212,6 +248,14 @@ impl App {
             }
         }
         self.visualizer.tx.send(VisualizerMsg::End)?;
+        self.shutdown()
+    }
+
+    /// Shuts down the device by turning it off and setting brightness to 0.
+    ///
+    /// Called after the main TUI loop exits to restore the device to an off state.
+    pub fn shutdown(&self) -> Result<()> {
+        self.nl_device.set_state(Some(false), Some(0))?;
         Ok(())
     }
 
@@ -230,6 +274,7 @@ impl App {
     /// - a/A: Toggle primary axis X/Y
     /// - p/P: Toggle primary sort Asc/Desc
     /// - s/S: Toggle secondary sort Asc/Desc
+    /// - e/E: Cycle visual effect (Spectrum / Energy Wave)
     /// - Defaults to NoOp for unhandled.
     ///
     /// View-specific logic, e.g., scroll only in EffectList.
@@ -265,7 +310,7 @@ impl App {
                 }
                 KeyCode::Char('g') => AppMsg::ScrollToTop,
                 KeyCode::Char('G') => AppMsg::ScrollToBottom,
-                KeyCode::Char('V') => match self.view {
+                KeyCode::Char('V') | KeyCode::Char('v') => match self.view {
                     AppView::HelpScreen => AppMsg::NoOp,
                     AppView::EffectList => AppMsg::ChangeView(AppView::Visualizer),
                     AppView::Visualizer => AppMsg::ChangeView(AppView::EffectList),
@@ -382,9 +427,71 @@ impl App {
                         AppMsg::NoOp
                     }
                 }
+                KeyCode::Char('e') | KeyCode::Char('E') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::CycleEffect
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('n') | KeyCode::Char('N') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::UseAlbumArtPalette
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
+                KeyCode::Char('r') | KeyCode::Char('R') => {
+                    if let AppView::Visualizer = self.view {
+                        AppMsg::ResetPanels
+                    } else {
+                        AppMsg::NoOp
+                    }
+                }
                 _ => AppMsg::NoOp,
             },
         }
+    }
+
+    /// Signals the album art watcher thread to stop, if one is running.
+    fn stop_album_art_watcher(&mut self) {
+        if let Some(stop) = self.visualizer.album_art_stop.take() {
+            stop.store(true, Ordering::Relaxed);
+        }
+        if let Ok(mut state) = self.visualizer.viz_state.lock() {
+            state.track_title = None;
+        }
+    }
+
+    /// Spawns a background thread that polls the current track title every 3 seconds.
+    /// When the title changes it fetches the new album art and sends SetPalette directly
+    /// to the visualizer thread. Stopped by setting the AtomicBool stop flag.
+    fn start_album_art_watcher(&mut self) {
+        self.stop_album_art_watcher();
+        let stop = Arc::new(AtomicBool::new(false));
+        self.visualizer.album_art_stop = Some(Arc::clone(&stop));
+        let tx = self.visualizer.tx.clone();
+        let viz_state = Arc::clone(&self.visualizer.viz_state);
+        std::thread::spawn(move || {
+            let mut last_title = crate::now_playing::get_track_title();
+            loop {
+                std::thread::sleep(Duration::from_secs(3));
+                if stop.load(Ordering::Relaxed) {
+                    break;
+                }
+                let title = crate::now_playing::get_track_title();
+                if title != last_title {
+                    last_title = title.clone();
+                    if let Some(colors) = crate::now_playing::fetch_palette() {
+                        if let Ok(mut state) = viz_state.lock() {
+                            state.colors = colors.clone();
+                            state.track_title = title;
+                        }
+                        let _ = tx.send(VisualizerMsg::SetPalette(colors));
+                    }
+                }
+            }
+        });
     }
 
     /// Applies an `AppMsg` to update application state, views, or external components.
@@ -407,6 +514,7 @@ impl App {
         match msg {
             AppMsg::NoOp => Ok(()),
             AppMsg::Quit => {
+                self.stop_album_art_watcher();
                 self.state = AppState::Done;
                 Ok(())
             }
@@ -486,11 +594,44 @@ impl App {
             AppMsg::ChangePalette(index) => {
                 if index < self.visualizer.palette_names.len() {
                     let palette_name = &self.visualizer.palette_names[index];
-                    if let Some(hues) = crate::palettes::get_palette(palette_name) {
+                    if let Some(colors) = crate::palettes::get_palette(palette_name) {
                         self.visualizer.current_palette_index = index;
-                        self.visualizer.tx.send(VisualizerMsg::SetPalette(hues))?;
+                        self.stop_album_art_watcher();
+                        if let Ok(mut state) = self.visualizer.viz_state.lock() {
+                            state.colors = colors.clone();
+                            state.track_title = None;
+                        }
+                        self.visualizer.tx.send(VisualizerMsg::SetPalette(colors))?;
                     }
                 }
+                Ok(())
+            }
+            AppMsg::UseAlbumArtPalette => {
+                eprintln!("DEBUG app: UseAlbumArtPalette triggered");
+                if let Some(colors) = crate::now_playing::fetch_palette() {
+                    let title = crate::now_playing::get_track_title();
+                    if let Ok(mut state) = self.visualizer.viz_state.lock() {
+                        state.colors = colors.clone();
+                        state.track_title = title;
+                    }
+                    self.visualizer.tx.send(VisualizerMsg::SetPalette(colors))?;
+                    self.start_album_art_watcher();
+                }
+                Ok(())
+            }
+            AppMsg::CycleEffect => {
+                self.visualizer.effect = match self.visualizer.effect {
+                    Effect::Spectrum => Effect::EnergyWave,
+                    Effect::EnergyWave => Effect::Pulse,
+                    Effect::Pulse => Effect::Spectrum,
+                };
+                self.visualizer
+                    .tx
+                    .send(VisualizerMsg::SetEffect(self.visualizer.effect))?;
+                Ok(())
+            }
+            AppMsg::ResetPanels => {
+                self.visualizer.tx.send(VisualizerMsg::ResetPanels)?;
                 Ok(())
             }
             AppMsg::ToggleAxis => {
@@ -595,12 +736,27 @@ impl App {
                 );
             }
             AppView::Visualizer => {
-                let current_palette = if self.visualizer.current_palette_index
-                    < self.visualizer.palette_names.len()
-                {
-                    &self.visualizer.palette_names[self.visualizer.current_palette_index]
-                } else {
-                    "Unknown"
+                // Snapshot display state from shared VizState (also written by watcher thread).
+                let (current_palette_name, track_title, palette_colors) = {
+                    let state = self.visualizer.viz_state.lock().unwrap();
+                    let name = if state.track_title.is_some() {
+                        "album-art".to_string()
+                    } else if self.visualizer.current_palette_index
+                        < self.visualizer.palette_names.len()
+                    {
+                        self.visualizer.palette_names[self.visualizer.current_palette_index]
+                            .clone()
+                    } else {
+                        "Unknown".to_string()
+                    };
+                    (name, state.track_title.clone(), state.colors.clone())
+                };
+                let current_palette = current_palette_name.as_str();
+
+                let effect_str = match self.visualizer.effect {
+                    Effect::Spectrum => "Spectrum",
+                    Effect::EnergyWave => "Energy Wave",
+                    Effect::Pulse => "Pulse",
                 };
 
                 let axis_str = match self.visualizer.primary_axis {
@@ -616,6 +772,16 @@ impl App {
                     Sort::Desc => "Desc",
                 };
 
+                // Build color swatch line: two spaces per color with background set.
+                let mut swatch_spans: Vec<Span> = vec!["Colors: ".into()];
+                for [r, g, b] in &palette_colors {
+                    swatch_spans.push(Span::styled(
+                        "  ",
+                        Style::default().bg(Color::Rgb(*r, *g, *b)),
+                    ));
+                    swatch_spans.push(" ".into());
+                }
+
                 let mut lines = vec![
                     Line::from("Music Visualizer".bold().cyan()),
                     Line::from(""),
@@ -624,6 +790,16 @@ impl App {
                         format!("{:.2}", self.visualizer.gain).blue(),
                     ]),
                     Line::from(vec!["Current palette: ".into(), current_palette.green()]),
+                ];
+                if let Some(title) = &track_title {
+                    lines.push(Line::from(vec![
+                        "Now playing: ".into(),
+                        title.as_str().cyan().italic(),
+                    ]));
+                }
+                lines.push(Line::from(swatch_spans));
+                lines.extend([
+                    Line::from(vec!["Effect [E]: ".into(), effect_str.magenta()]),
                     Line::from(""),
                     Line::from("Panel Sorting:".bold()),
                     Line::from(vec![
@@ -636,7 +812,7 @@ impl App {
                     ]),
                     Line::from(""),
                     Line::from("Available Palettes (press number to switch):".bold()),
-                ];
+                ]);
 
                 for (i, palette_name) in self.visualizer.palette_names.iter().enumerate().take(10) {
                     let key = if i == 9 {
@@ -672,12 +848,15 @@ impl App {
                         Line::from(vec!["g/G".bold(), " - go to the top/bottom of the list".into()]),
                         Line::from(vec!["j/Down, k/Up".bold(), " - scroll down and up".into()]),
                         Line::from(vec!["Enter".bold(), " - play selected effect".into()]),
-                        Line::from(vec!["V".bold(), " - toggle music visualizer mode".into()]),
+                        Line::from(vec!["V/v".bold(), " - toggle music visualizer mode".into()]),
                         Line::from(vec!["-/+".bold(), " - decrease/increase gain (in visualizer mode)".into()]),
                         Line::from(vec!["1-9, 0".bold(), " - switch color palette (in visualizer mode)".into()]),
                         Line::from(vec!["A".bold(), " - toggle primary axis X/Y (in visualizer mode)".into()]),
                         Line::from(vec!["P".bold(), " - toggle primary sort Asc/Desc (in visualizer mode)".into()]),
                         Line::from(vec!["S".bold(), " - toggle secondary sort Asc/Desc (in visualizer mode)".into()]),
+                        Line::from(vec!["E".bold(), " - cycle visual effect: Spectrum / Energy Wave / Pulse (in visualizer mode)".into()]),
+                        Line::from(vec!["N".bold(), " - use album art colors from current track (in visualizer mode)".into()]),
+                        Line::from(vec!["R".bold(), " - reset all panels to black (in visualizer mode)".into()]),
                         Line::from(vec!["(note that gain doesn't affect your music volume, only the visuals are amplified)".italic()]),
                     ])
                     .block(main_block)

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -9,6 +9,24 @@ pub struct AudioStream {
 }
 
 impl AudioStream {
+    /// Creates a new `AudioStream` instance for capturing audio from an input device.
+    ///
+    /// Prioritizes loopback/monitor devices for system-wide audio capture (e.g., BlackHole on macOS).
+    /// Searches common names like "BlackHole", "Loopback Audio", etc.
+    /// Falls back to the system's default input device (often microphone) with a warning.
+    /// Supports specifying a custom device name via `device_name`.
+    ///
+    /// # Arguments
+    ///
+    /// * `device_name` - Optional name of the audio device to use. Defaults to automatic loopback detection.
+    ///
+    /// # Returns
+    ///
+    /// `Result<Self>` with the configured `AudioStream` containing device, sample format, and config.
+    ///
+    /// # Errors
+    ///
+    /// Propagates `cpal` errors for device discovery or config retrieval. Bail with available devices list if none match.
     pub fn new(device_name: Option<&str>) -> Result<Self> {
         let device_name = match device_name {
             Some(name) => name,

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -1,6 +1,6 @@
 use crate::constants;
-use anyhow::{bail, Result};
-use cpal::{traits::*, Device, SampleFormat, StreamConfig};
+use anyhow::{Result, bail};
+use cpal::{Device, SampleFormat, StreamConfig, traits::*};
 
 pub struct AudioStream {
     pub device: Device,
@@ -52,7 +52,7 @@ impl AudioStream {
                 let mut loopback_device = None;
                 if let Ok(devices) = host.input_devices() {
                     for device in devices {
-                        if let Ok(name) = device.name() {
+                        if let Ok(name) = device.description().map(|d| d.name().to_string()) {
                             if loopback_names.iter().any(|lb| name.contains(lb)) {
                                 eprintln!("INFO: Found loopback device: {}", name);
                                 loopback_device = Some(device);
@@ -69,9 +69,11 @@ impl AudioStream {
                     host.default_input_device()
                 })
             }
-            _ => host
-                .input_devices()?
-                .find(|x| x.name().map(|y| y == device_name).unwrap_or(false)),
+            _ => host.input_devices()?.find(|x| {
+                x.description()
+                    .map(|d| d.name() == device_name)
+                    .unwrap_or(false)
+            }),
         };
 
         let Some(device) = device else {
@@ -79,7 +81,10 @@ impl AudioStream {
                 "Audio backend `{}` not found, available options: {}",
                 device_name,
                 host.input_devices()?
-                    .map(|dev| dev.name().unwrap_or_default())
+                    .map(|dev| dev
+                        .description()
+                        .map(|d| d.name().to_string())
+                        .unwrap_or_default())
                     .collect::<Vec<_>>()
                     .join(", ")
             ));

--- a/src/audio.rs
+++ b/src/audio.rs
@@ -15,12 +15,47 @@ impl AudioStream {
             None => constants::DEFAULT_AUDIO_BACKEND,
         };
         let host = cpal::default_host();
+
+        // Try to find the device in input devices (for loopback/monitor devices)
         let device = match device_name {
-            constants::DEFAULT_AUDIO_BACKEND => host.default_input_device(),
+            constants::DEFAULT_AUDIO_BACKEND => {
+                // Check for common loopback device names first
+                let loopback_names = [
+                    "BlackHole",
+                    "BlackHole 2ch",
+                    "BlackHole 16ch",
+                    "Loopback Audio",
+                    "CABLE Output",
+                    "VB-Audio",
+                    "Monitor",
+                    "monitor",
+                ];
+
+                let mut loopback_device = None;
+                if let Ok(devices) = host.input_devices() {
+                    for device in devices {
+                        if let Ok(name) = device.name() {
+                            if loopback_names.iter().any(|lb| name.contains(lb)) {
+                                eprintln!("INFO: Found loopback device: {}", name);
+                                loopback_device = Some(device);
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                // Fall back to default input if no loopback found
+                loopback_device.or_else(|| {
+                    eprintln!("WARNING: No loopback device found. Using default input device (microphone).");
+                    eprintln!("To capture system audio on macOS, install BlackHole: https://github.com/ExistentialAudio/BlackHole");
+                    host.default_input_device()
+                })
+            }
             _ => host
                 .input_devices()?
                 .find(|x| x.name().map(|y| y == device_name).unwrap_or(false)),
         };
+
         let Some(device) = device else {
             bail!(format!(
                 "Audio backend `{}` not found, available options: {}",

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::{constants, ssdp, utils};
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::Parser;
 use serde::Serialize;
 use std::fs::File;
@@ -85,17 +85,36 @@ pub enum Sort {
     Desc,
 }
 
+/// Visual effect mode for the audio visualizer.
+///
+/// Controls how audio data maps to panel brightness/color animation.
+#[derive(Copy, Clone, Debug, Default, Serialize)]
+pub enum Effect {
+    /// Each panel independently tracks a logarithmic frequency band.
+    /// Brightness pulses with audio energy in that band (fast attack, slow decay).
+    #[default]
+    Spectrum,
+    /// Audio energy enters from one end and cascades across panels as a traveling wave.
+    /// Creates a flowing ripple effect driven by overall audio amplitude.
+    EnergyWave,
+    /// All panels pulse together, driven directly by audio transients.
+    /// Very fast attack snaps to each beat; smooth exponential decay fades between hits.
+    /// The music's own rhythm drives the animation — no fixed oscillation.
+    Pulse,
+}
+
 #[derive(Debug, Serialize)]
 pub struct VisualizerConfig {
     pub audio_backend: Option<String>,
     pub freq_range: Option<(u16, u16)>,
-    pub hues: Option<Vec<u16>>,
+    pub colors: Option<Vec<[u8; 3]>>,
     pub default_gain: Option<f32>,
-    pub transition_time: Option<i16>,
+    pub transition_time: Option<u16>,
     pub time_window: Option<f32>,
     pub primary_axis: Option<Axis>,
     pub sort_primary: Option<Sort>,
     pub sort_secondary: Option<Sort>,
+    pub effect: Option<Effect>,
 }
 
 impl VisualizerConfig {
@@ -104,7 +123,7 @@ impl VisualizerConfig {
     /// Initializes with constants:
     /// - `audio_backend`: "default"
     /// - `freq_range`: (20, 4500) Hz
-    /// - `hues`: Standard rainbow-like [30,0,330,...]
+    /// - `colors`: RGB color array for panel visualization
     /// - `default_gain`: 1.0
     /// - `transition_time`: 2 (200ms)
     /// - `time_window`: 0.1875 s
@@ -113,13 +132,22 @@ impl VisualizerConfig {
         VisualizerConfig {
             audio_backend: Some("default".to_string()),
             freq_range: Some(constants::DEFAULT_FREQ_RANGE),
-            hues: Some(vec![30, 0, 330, 300, 270, 240, 210]),
+            colors: Some(vec![
+                [255, 128, 0],
+                [255, 0, 0],
+                [255, 0, 128],
+                [255, 0, 255],
+                [128, 0, 255],
+                [0, 0, 255],
+                [0, 128, 255],
+            ]),
             default_gain: Some(constants::DEFAULT_GAIN),
             transition_time: Some(constants::DEFAULT_TRANSITION_TIME),
             time_window: Some(constants::DEFAULT_TIME_WINDOW),
             primary_axis: Some(Axis::default()),
             sort_primary: Some(Sort::default()),
             sort_secondary: Some(Sort::default()),
+            effect: Some(Effect::default()),
         }
     }
 }
@@ -186,14 +214,14 @@ impl Config {
     /// Supports comprehensive field validation and type conversion:
     /// - `audio_backend`: String for device name.
     /// - `freq_range`: 2-element array of u16 [min_hz, max_hz].
-    /// - `hues`: Array of u16 (0-360) or string name of predefined palette (e.g., "ocean-nightclub").
+    /// - `colors`: Array of [R,G,B] triplets or string name of predefined palette (e.g., "ocean-nightclub").
     /// - `default_gain`: f32 or i64, applied to spectrum amplitudes.
-    /// - `transition_time`: i16 (-1 for instant, positive in 100ms units for Nanoleaf transitions).
+    /// - `transition_time`: u16 in 100ms units for Nanoleaf transitions (0 = instant).
     /// - `time_window`: f32 seconds for smoothing window.
     /// - `primary_axis`: "X" or "Y" enum.
     /// - `sort_primary`/`sort_secondary`: "Asc" or "Desc".
     ///
-    /// Validates ranges (e.g., hues 0-360, transition_time >= -1) and bails on errors or unknown keys.
+    /// Validates ranges (e.g., RGB 0-255, transition_time >= 0) and bails on errors or unknown keys.
     /// Palette names checked against available predefined palettes.
     ///
     /// # Arguments
@@ -223,10 +251,10 @@ impl Config {
                     visualizer_config.freq_range =
                         Some((u16::try_from(low)?, u16::try_from(high)?));
                 }
-                ("hues", Value::String(s)) => {
+                ("colors" | "hues", Value::String(s)) => {
                     // Named palette support
                     match crate::palettes::get_palette(&s) {
-                        Some(hues) => visualizer_config.hues = Some(hues),
+                        Some(colors) => visualizer_config.colors = Some(colors),
                         None => {
                             let available = crate::palettes::get_palette_names().join(", ");
                             bail!(
@@ -237,21 +265,55 @@ impl Config {
                         }
                     }
                 }
-                ("hues", Value::Array(v)) => {
+                ("colors" | "hues", Value::Array(v)) => {
                     if v.is_empty() {
-                        bail!("hues cannot be an empty array");
+                        bail!("colors cannot be an empty array");
                     }
-                    if v.iter().map(|x| x.as_integer()).any(|x| match x.as_ref() {
-                        Some(x) => !(0..=360).contains(x),
-                        None => true,
-                    }) {
-                        bail!("hues must be integers from 0 to 360 inclusive (360 = white)");
+                    // Detect format: if first element is an integer, treat as legacy hue array;
+                    // if first element is an array, treat as RGB color array.
+                    if v[0].is_integer() {
+                        // Legacy hue format: [30, 0, 330, ...] → convert HSV hues to RGB
+                        let mut colors = Vec::with_capacity(v.len());
+                        for (i, entry) in v.iter().enumerate() {
+                            let Some(hue_val) = entry.as_integer() else {
+                                bail!("hues[{}] must be an integer (0-360)", i);
+                            };
+                            if !(0..=360).contains(&hue_val) {
+                                bail!("hues[{}] must be 0-360, got {}", i, hue_val);
+                            }
+                            if hue_val == 360 {
+                                colors.push([255, 255, 255]); // white
+                            } else {
+                                // Convert HSV hue (S=1, V=1) to RGB
+                                let rgb = hsv_hue_to_rgb(hue_val as f32);
+                                colors.push(rgb);
+                            }
+                        }
+                        visualizer_config.colors = Some(colors);
+                    } else {
+                        // New RGB format: [[255, 0, 0], [0, 255, 0], ...]
+                        let mut colors = Vec::with_capacity(v.len());
+                        for (i, entry) in v.iter().enumerate() {
+                            let Some(rgb_arr) = entry.as_array() else {
+                                bail!("colors[{}] must be a [R, G, B] array", i);
+                            };
+                            if rgb_arr.len() != 3 {
+                                bail!("colors[{}] must be a 3-element [R, G, B] array", i);
+                            }
+                            let mut rgb = [0u8; 3];
+                            for (j, component) in rgb_arr.iter().enumerate() {
+                                let Some(val) = component.as_integer() else {
+                                    bail!("colors[{}][{}] must be an integer (0-255)", i, j);
+                                };
+                                if !(0..=255).contains(&val) {
+                                    bail!("colors[{}][{}] must be 0-255, got {}", i, j, val);
+                                }
+                                rgb[j] = val as u8;
+                            }
+                            colors.push(rgb);
+                        }
+                        visualizer_config.colors = Some(colors);
                     }
-                    let hues: Vec<u16> = v
-                        .into_iter()
-                        .map(|x| u16::try_from(x.as_integer().unwrap()).unwrap())
-                        .collect();
-                    visualizer_config.hues = Some(hues);
                 }
                 ("default_gain", Value::Float(x)) => {
                     eprintln!("DEBUG: Parsed default_gain as Float: {}", x);
@@ -262,10 +324,11 @@ impl Config {
                     visualizer_config.default_gain = Some(x as f32);
                 }
                 ("transition_time", Value::Integer(x)) => {
-                    let trans_time = i16::try_from(x)?;
-                    if trans_time < -1 {
-                        bail!("transition_time must be -1 (instant) or a positive value. Note: units are in 100ms (1 = 100ms, 2 = 200ms, etc.)");
-                    }
+                    let trans_time = u16::try_from(x).map_err(|_| {
+                        anyhow::anyhow!(
+                            "transition_time must be 0-65535. Note: units are in 100ms (0 = instant, 1 = 100ms, 2 = 200ms, etc.)"
+                        )
+                    })?;
                     visualizer_config.transition_time = Some(trans_time);
                 }
                 ("time_window", Value::Float(x)) => {
@@ -303,6 +366,21 @@ impl Config {
                         bail!("sort must be `Asc` (ascending) or `Desc` (descending)");
                     };
                     visualizer_config.sort_secondary = sort;
+                }
+                ("effect", Value::String(s)) => {
+                    let effect = match s.as_str() {
+                        "Spectrum" | "spectrum" => Some(Effect::Spectrum),
+                        "EnergyWave" | "energy_wave" | "energy-wave" => Some(Effect::EnergyWave),
+                        "Pulse" | "pulse" => Some(Effect::Pulse),
+                        _ => None,
+                    };
+                    if effect.is_none() {
+                        bail!(
+                            "effect must be `Spectrum`, `EnergyWave`, or `Pulse`, got `{}`",
+                            s
+                        );
+                    };
+                    visualizer_config.effect = effect;
                 }
                 (key, _) => {
                     bail!(format!("invalid key `{}`", key));
@@ -444,6 +522,24 @@ pub fn resolve_paths(
         (config_file_path, config_file_exists),
         (devices_file_path, devices_file_exists),
     ))
+}
+
+/// Converts an HSV hue (with S=1, V=1) to an RGB triplet.
+///
+/// Used for backwards compatibility with legacy config files that specify
+/// colors as hue angles (0-360) instead of RGB arrays.
+fn hsv_hue_to_rgb(hue: f32) -> [u8; 3] {
+    let h = hue / 60.0;
+    let x = 1.0 - (h % 2.0 - 1.0).abs();
+    let (r, g, b) = match h as u32 {
+        0 => (1.0, x, 0.0),
+        1 => (x, 1.0, 0.0),
+        2 => (0.0, 1.0, x),
+        3 => (0.0, x, 1.0),
+        4 => (x, 0.0, 1.0),
+        _ => (1.0, 0.0, x),
+    };
+    [(r * 255.0) as u8, (g * 255.0) as u8, (b * 255.0) as u8]
 }
 
 /// Interactively discovers Nanoleaf devices via SSDP or accepts manual IP input.

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,30 @@ pub struct CliOptions {
     /// Explicitly add a new Nanoleaf device
     #[arg(short = 'n', long = "new")]
     pub add_new: bool,
+
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Parser, Debug)]
+pub enum Command {
+    /// Dump information from device or configuration
+    Dump {
+        #[command(subcommand)]
+        dump_type: DumpType,
+    },
+}
+
+#[derive(Parser, Debug)]
+pub enum DumpType {
+    /// Dump panel layout information from the device
+    Layout,
+    /// Dump available color palettes
+    Palettes,
+    /// Dump device info from /api/v1/ endpoint (no auth required)
+    Info,
+    /// Show graphical panel layout visualization
+    LayoutGraphical,
 }
 
 #[derive(Debug, Serialize)]
@@ -50,7 +74,7 @@ pub enum Axis {
     Y,
 }
 
-#[derive(Debug, Default, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Serialize)]
 pub enum Sort {
     #[default]
     Asc,
@@ -63,7 +87,7 @@ pub struct VisualizerConfig {
     pub freq_range: Option<(u16, u16)>,
     pub hues: Option<Vec<u16>>,
     pub default_gain: Option<f32>,
-    pub transition_time: Option<u16>,
+    pub transition_time: Option<i16>,
     pub time_window: Option<f32>,
     pub primary_axis: Option<Axis>,
     pub sort_primary: Option<Sort>,
@@ -178,7 +202,11 @@ impl Config {
                     visualizer_config.default_gain = Some(x as f32);
                 }
                 ("transition_time", Value::Integer(x)) => {
-                    visualizer_config.transition_time = Some(u16::try_from(x)?);
+                    let trans_time = i16::try_from(x)?;
+                    if trans_time < -1 {
+                        bail!("transition_time must be -1 (instant) or a positive value. Note: units are in 100ms (1 = 100ms, 2 = 200ms, etc.)");
+                    }
+                    visualizer_config.transition_time = Some(trans_time);
                 }
                 ("time_window", Value::Float(x)) => {
                     visualizer_config.time_window = Some(x as f32);

--- a/src/config.rs
+++ b/src/config.rs
@@ -60,6 +60,10 @@ pub struct TuiConfig {
 }
 
 impl TuiConfig {
+    /// Returns the default TUI configuration.
+    ///
+    /// Sets `colorful_effect_names` to the constant `DEFAULT_COLORFUL_EFFECT_NAMES` (typically false,
+    /// meaning effect names in the effect list are displayed without per-character coloring based on palette).
     pub fn default() -> Self {
         TuiConfig {
             colorful_effect_names: Some(constants::DEFAULT_COLORFUL_EFFECT_NAMES),
@@ -95,6 +99,16 @@ pub struct VisualizerConfig {
 }
 
 impl VisualizerConfig {
+    /// Returns the default visualizer configuration.
+    ///
+    /// Initializes with constants:
+    /// - `audio_backend`: "default"
+    /// - `freq_range`: (20, 4500) Hz
+    /// - `hues`: Standard rainbow-like [30,0,330,...]
+    /// - `default_gain`: 1.0
+    /// - `transition_time`: 2 (200ms)
+    /// - `time_window`: 0.1875 s
+    /// - Sorting: Y axis ascending, secondary ascending
     pub fn default() -> Self {
         VisualizerConfig {
             audio_backend: Some("default".to_string()),
@@ -118,6 +132,15 @@ pub struct Config {
 }
 
 impl Config {
+    /// Constructs a new `Config` instance with optional component overrides.
+    ///
+    /// Uses defaults for unspecified sub-configs via their `default()` methods.
+    ///
+    /// # Arguments
+    ///
+    /// * `default_nl_device_name` - Optional default Nanoleaf device name for quick selection.
+    /// * `tui_config` - Optional TUI settings; defaults to `TuiConfig::default()`.
+    /// * `visualizer_config` - Optional visualizer params; defaults to `VisualizerConfig::default()`.
     pub fn new(
         default_nl_device_name: Option<String>,
         tui_config: Option<TuiConfig>,
@@ -130,6 +153,20 @@ impl Config {
         }
     }
 
+    /// Parses a TOML table into the fields of a mutable `TuiConfig`.
+    ///
+    /// Supports key "colorful_effect_names" as boolean value.
+    /// Ignores unknown keys? No, bails with error on invalid keys.
+    /// Updates `tui_config` in place.
+    ///
+    /// # Arguments
+    ///
+    /// * `tui_config` - Mutable reference to populate.
+    /// * `t` - TOML table from config section.
+    ///
+    /// # Errors
+    ///
+    /// `anyhow::Error` for invalid key types or unknown keys.
     pub fn parse_tui_config(tui_config: &mut TuiConfig, t: toml::Table) -> Result<()> {
         for (key, val) in t {
             match (key.as_str(), val) {
@@ -144,6 +181,29 @@ impl Config {
         Ok(())
     }
 
+    /// Parses a TOML table into the fields of a mutable `VisualizerConfig`.
+    ///
+    /// Supports comprehensive field validation and type conversion:
+    /// - `audio_backend`: String for device name.
+    /// - `freq_range`: 2-element array of u16 [min_hz, max_hz].
+    /// - `hues`: Array of u16 (0-360) or string name of predefined palette (e.g., "ocean-nightclub").
+    /// - `default_gain`: f32 or i64, applied to spectrum amplitudes.
+    /// - `transition_time`: i16 (-1 for instant, positive in 100ms units for Nanoleaf transitions).
+    /// - `time_window`: f32 seconds for smoothing window.
+    /// - `primary_axis`: "X" or "Y" enum.
+    /// - `sort_primary`/`sort_secondary`: "Asc" or "Desc".
+    ///
+    /// Validates ranges (e.g., hues 0-360, transition_time >= -1) and bails on errors or unknown keys.
+    /// Palette names checked against available predefined palettes.
+    ///
+    /// # Arguments
+    ///
+    /// * `visualizer_config` - Mutable reference to update.
+    /// * `t` - TOML table from [visualizer_config] section.
+    ///
+    /// # Errors
+    ///
+    /// `anyhow::Error` for parsing failures, invalid values, or unknown keys.
     pub fn parse_visualizer_config(
         visualizer_config: &mut VisualizerConfig,
         t: toml::Table,
@@ -252,6 +312,28 @@ impl Config {
         Ok(())
     }
 
+    /// Loads and parses the full application configuration from a TOML file.
+    ///
+    /// Reads the file content, deserializes to TOML `Table`, then:
+    /// - Extracts optional `default_nl_device_name` string.
+    /// - Parses `[tui_config]` section using `parse_tui_config`.
+    /// - Parses `[visualizer_config]` section using `parse_visualizer_config`.
+    /// - Uses defaults for missing sections or fields.
+    /// - Bails on unknown top-level keys or sub-config parse errors.
+    ///
+    /// Debug-logs file path and contents for verification.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the config.toml file.
+    ///
+    /// # Returns
+    ///
+    /// `Result<Config>` - Fully parsed and validated configuration.
+    ///
+    /// # Errors
+    ///
+    /// File I/O errors, TOML deserialization failures, or validation bails.
     pub fn parse_from_file(path: &Path) -> Result<Self> {
         eprintln!("DEBUG: Reading config from: {}", path.display());
         let mut config_file = File::open(path)?;
@@ -286,6 +368,19 @@ impl Config {
         ))
     }
 
+    /// Serializes and writes the configuration to a TOML file at the given path.
+    ///
+    /// Uses `toml::to_string_pretty` for readable formatting.
+    /// Automatically creates parent directories if they do not exist.
+    ///
+    /// # Arguments
+    ///
+    /// * `self` - The config to serialize.
+    /// * `path` - Target file path for config.toml.
+    ///
+    /// # Errors
+    ///
+    /// Propagates `std::fs` errors for directory creation or file writing, or TOML serialization errors.
     pub fn write_to_file(&self, path: &Path) -> Result<()> {
         // Create parent directory if it doesn't exist
         if let Some(parent) = path.parent() {
@@ -298,6 +393,23 @@ impl Config {
     }
 }
 
+/// Resolves absolute paths for configuration and devices TOML files.
+///
+/// Defaults to XDG config dir (~/.config/audioleaf/) + default filenames if not provided.
+/// Checks file existence (returns bool in tuple) and permissions.
+///
+/// # Arguments
+///
+/// * `config_file_path` - Optional override for config.toml path.
+/// * `devices_file_path` - Optional override for nl_devices.toml path.
+///
+/// # Returns
+///
+/// `Result<((PathBuf, bool), (PathBuf, bool))>` - Resolved paths and their existence flags.
+///
+/// # Errors
+///
+/// `anyhow::Error` if insufficient permissions to check path existence.
 pub fn resolve_paths(
     config_file_path: Option<PathBuf>,
     devices_file_path: Option<PathBuf>,
@@ -334,6 +446,19 @@ pub fn resolve_paths(
     ))
 }
 
+/// Interactively discovers Nanoleaf devices via SSDP or accepts manual IP input.
+///
+/// Performs SSDP M-SEARCH to find devices on network, lists names/IPs for user choice.
+/// Supports automatic selection by number, 'M' for manual IP entry, 'Q' to quit.
+/// Prompts user to enable pairing mode on device before returning selected IP.
+///
+/// # Returns
+///
+/// `Result<Ipv4Addr>` - The chosen device IP address.
+///
+/// # Errors
+///
+/// Propagates errors from SSDP discovery, IP parsing, or user abort (bail!).
 pub fn get_ip() -> Result<Ipv4Addr> {
     let (names, ips) = ssdp::ssdp_msearch()?;
     let choice = utils::choose_ip(&names)?;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -6,7 +6,10 @@ pub const DEFAULT_AUDIO_BACKEND: &str = "default";
 pub const DEFAULT_FREQ_RANGE: (u16, u16) = (20, 4500);
 pub const DEFAULT_HUES: [u16; 12] = [50, 30, 10, 350, 330, 310, 290, 270, 250, 230, 210, 190];
 pub const DEFAULT_GAIN: f32 = 1.0;
-pub const DEFAULT_TRANSITION_TIME: u16 = 2;
+// Transition time in units of 100ms (1 = 100ms, 2 = 200ms, etc.)
+// -1 is special: instant transition (start frame), used to avoid lengthy initial transitions
+// Recommended: Use values that align with your time_window for smooth transitions
+pub const DEFAULT_TRANSITION_TIME: i16 = 2;
 pub const DEFAULT_TIME_WINDOW: f32 = 0.1875;
 
 // other

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -4,12 +4,24 @@ pub const DEFAULT_COLORFUL_EFFECT_NAMES: bool = false;
 // visualizer config
 pub const DEFAULT_AUDIO_BACKEND: &str = "default";
 pub const DEFAULT_FREQ_RANGE: (u16, u16) = (20, 4500);
-pub const DEFAULT_HUES: [u16; 12] = [50, 30, 10, 350, 330, 310, 290, 270, 250, 230, 210, 190];
+pub const DEFAULT_COLORS: [[u8; 3]; 12] = [
+    [255, 213, 0], // golden
+    [255, 128, 0], // orange
+    [255, 43, 0],  // scarlet
+    [255, 0, 43],  // rose
+    [255, 0, 128], // hot pink
+    [255, 0, 213], // fuchsia
+    [213, 0, 255], // purple
+    [128, 0, 255], // violet
+    [43, 0, 255],  // indigo
+    [0, 43, 255],  // cobalt
+    [0, 128, 255], // azure
+    [0, 213, 255], // sky blue
+];
 pub const DEFAULT_GAIN: f32 = 1.0;
-// Transition time in units of 100ms (1 = 100ms, 2 = 200ms, etc.)
-// -1 is special: instant transition (start frame), used to avoid lengthy initial transitions
+// Transition time in units of 100ms (0 = instant, 1 = 100ms, 2 = 200ms, etc.)
 // Recommended: Use values that align with your time_window for smooth transitions
-pub const DEFAULT_TRANSITION_TIME: i16 = 2;
+pub const DEFAULT_TRANSITION_TIME: u16 = 2;
 pub const DEFAULT_TIME_WINDOW: f32 = 0.1875;
 
 // other

--- a/src/event_handler.rs
+++ b/src/event_handler.rs
@@ -13,6 +13,16 @@ pub struct EventHandler {
 }
 
 impl EventHandler {
+    /// Creates a new `EventHandler` that polls for terminal events and ticks.
+    ///
+    /// Spawns a background thread to:
+    /// - Poll for key events (only processes KeyEventKind::Press to avoid repeats).
+    /// - Send `Event::Key` or `Event::Tick` via mpsc channel at `constants::TICKRATE` ms intervals.
+    /// - Registers panic handler in the thread for crash logging.
+    ///
+    /// # Returns
+    ///
+    /// `EventHandler` with receiver channel for events.
     pub fn new() -> Self {
         let tickrate = Duration::from_millis(constants::TICKRATE);
         let (tx, rx) = mpsc::channel();
@@ -35,6 +45,13 @@ impl EventHandler {
         EventHandler { rx }
     }
 
+    /// Blocks and receives the next event from the event handler channel.
+    ///
+    /// Used in the main loop to process keyboard input or ticks for UI updates.
+    ///
+    /// # Returns
+    ///
+    /// `Result<Event>` - The received event, or error if channel recv fails (e.g., sender dropped).
     pub fn next(&self) -> Result<Event> {
         Ok(self.rx.recv()?)
     }

--- a/src/graphical_layout.rs
+++ b/src/graphical_layout.rs
@@ -1,7 +1,7 @@
 use crate::layout_visualizer::PanelInfo;
 use crate::nanoleaf::NlDevice;
 use macroquad::prelude::*;
-use palette::Hwb;
+use palette::Oklch;
 use std::f32::consts::PI;
 use std::thread;
 use std::time::Duration;
@@ -146,7 +146,16 @@ async fn visualize_loop(panels: Vec<PanelInfo>, global_orientation: u16, device:
     // Initialize optional UDP controller using device IP and token for flashing panels.
     // Gracefully handles initialization failure by disabling clicks but continuing render.
     let nl_controller = match crate::nanoleaf::NlUdp::new(&device) {
-        Ok(controller) => Some(controller),
+        Ok(controller) => {
+            // Blank all panels to black so only clicked panels light up
+            let black_colors: Vec<Oklch> = panels
+                .iter()
+                .filter(|p| p.shape_type.side_length >= 1.0)
+                .map(|_| Oklch::new(0.0, 0.0, 0.0))
+                .collect();
+            let _ = controller.update_panels(&black_colors, 0);
+            Some(controller)
+        }
         Err(e) => {
             eprintln!("Warning: Could not initialize Nanoleaf controller: {}", e);
             None
@@ -504,7 +513,7 @@ fn draw_panel(
 
 /// Flashes a specific panel white briefly by sending UDP color updates.
 ///
-/// Sets the clicked panel to white (Hwb(359,0,0)) and all other light panels to black (Hwb(0,0,1)).
+/// Sets the clicked panel to white (Oklch L=1, C=0) and all other light panels to black (Oklch L=0, C=0).
 /// Updates immediately (transition=1), waits 300ms, then sets all light panels back to black.
 ///
 /// Only affects panels with side_length >=1.0 (light panels, skips controllers).
@@ -519,16 +528,16 @@ fn flash_panel(
     all_panels: &[PanelInfo],
     clicked_panel_id: u16,
 ) {
-    // Construct per-panel Hwb colors for UDP update: white (Hwb::new(359.0, 0.0, 0.0)) for clicked,
-    // black (Hwb::new(0.0, 0.0, 1.0)) for other light panels; exclude controllers from array.
-    let colors: Vec<Hwb> = all_panels
+    // Construct per-panel Oklch colors for UDP update: white (L=1, C=0) for clicked,
+    // black (L=0, C=0) for other light panels; exclude controllers from array.
+    let colors: Vec<Oklch> = all_panels
         .iter()
         .filter(|panel| panel.shape_type.side_length >= 1.0)
         .map(|panel| {
             if panel.panel_id == clicked_panel_id {
-                Hwb::new(359.0, 0.0, 0.0) // White
+                Oklch::new(1.0, 0.0, 0.0) // White
             } else {
-                Hwb::new(0.0, 0.0, 1.0) // Black
+                Oklch::new(0.0, 0.0, 0.0) // Black
             }
         })
         .collect();
@@ -540,11 +549,10 @@ fn flash_panel(
     thread::sleep(Duration::from_millis(300));
 
     // Reset flash: update all light panels to black, effectively turning off the highlight
-    // (note: this overrides any current effect; in practice, may need to restore original colors for seamless integration).
-    let black_colors: Vec<Hwb> = all_panels
+    let black_colors: Vec<Oklch> = all_panels
         .iter()
         .filter(|panel| panel.shape_type.side_length >= 1.0)
-        .map(|_| Hwb::new(0.0, 0.0, 1.0))
+        .map(|_| Oklch::new(0.0, 0.0, 0.0))
         .collect();
     let _ = controller.update_panels(&black_colors, 1);
 }

--- a/src/graphical_layout.rs
+++ b/src/graphical_layout.rs
@@ -6,20 +6,119 @@ use std::f32::consts::PI;
 use std::thread;
 use std::time::Duration;
 
+/// graphical_layout - Graphical Visualization of Nanoleaf Panel Layouts
+///
+/// This module provides an interactive graphical interface to visualize and interact with
+/// Nanoleaf panel layouts using the macroquad rendering engine. It renders panels as
+/// polygons scaled to fit the window, applies global orientation rotations, and supports
+/// mouse interaction for flashing individual panels via UDP commands.
+///
+/// ## Main Components
+///
+/// - `visualize_graphical`: Entry point function to launch the visualization window.
+/// - `visualize_loop`: Core async loop handling rendering and input.
+/// - `draw_panel`: Renders individual panels or controller trapezoids.
+/// - `flash_panel`: Sends UDP color updates to flash a panel white briefly.
+///
+/// ## Color Mapping for Panels
+///
+/// Panels are colored by shape family:
+/// - Triangles (IDs 0,8,9): Red-ish
+/// - Squares (2-4): Green-ish
+/// - Hexagons (7,14,15): Blue-ish
+/// - Skylight panels (30-32): Yellow-ish
+/// - Others: Gray
+///
+/// Controllers are always yellow trapezoids labeled "C".
+///
+/// ## Interaction
+///
+/// - Left-click a panel to flash it.
+/// - ESC to exit.
+/// - Window auto-scales layout with padding.
+///
+/// ## Error Handling
+///
+/// Warns if UDP controller fails to initialize but continues without interaction.
+/// Relies on `pollster::block_on` for async compatibility.
+/// Visualizes the Nanoleaf panel layout in a graphical window using the macroquad game engine.
+///
+/// This function creates an interactive window displaying the physical arrangement of Nanoleaf panels.
+/// Panels are rendered as colored polygons based on their shape type (triangles, squares, hexagons).
+/// Controller panels are depicted as yellow trapezoids attached to nearby light panels.
+/// The layout can be rotated according to the global orientation.
+/// Users can click on panels to briefly flash them white using UDP commands to the device.
+///
+/// The window includes:
+/// - Title showing global orientation
+/// - Scaled and centered layout
+/// - Panel IDs labeled in centers
+/// - Instructions for interaction
+///
+/// Press ESC to close the window.
+///
+/// # Arguments
+///
+/// * `panels` - Vector of `PanelInfo` structs describing each panel's position, orientation, and shape.
+/// * `global_orientation` - The global rotation of the layout in degrees (u16).
+/// * `device` - `NlDevice` containing IP and auth token for UDP communication.
+///
+/// # Panics
+///
+/// Panics if macroquad window creation or async runtime fails.
+///
+/// # Examples
+///
+/// ```
+/// // Assuming panels and device are obtained from layout parsing
+/// visualize_graphical(panels, global_orientation, device);
+/// ```
+///
+/// # Dependencies
+///
+/// Requires `macroquad` and `palette` crates for rendering and color handling.
 pub fn visualize_graphical(panels: Vec<PanelInfo>, global_orientation: u16, device: NlDevice) {
-    // Run the visualization synchronously
+    // Synchronously block on the async visualization routine using pollster::block_on,
+    // bridging the synchronous entry point to macroquad's async window and event loop.
     pollster::block_on(visualize_async(panels, global_orientation, device));
 }
 
+/// Asynchronous function that sets up the macroquad window and runs the visualization loop.
+///
+/// This private helper function is called by `visualize_graphical` to handle the async nature
+/// of macroquad's event loop. It creates a window titled "Nanoleaf Panel Layout" and awaits
+/// the main loop execution.
+///
+/// # Arguments
+///
+/// * `panels` - The panel layout data.
+/// * `global_orientation` - Device global orientation.
+/// * `device` - Nanoleaf device for interaction.
 async fn visualize_async(panels: Vec<PanelInfo>, global_orientation: u16, device: NlDevice) {
-    // Initialize macroquad window
+    // Create and configure the macroquad window with fixed size and title,
+    // then spawn the async block to run the main visualization loop.
     macroquad::Window::new("Nanoleaf Panel Layout", async move {
         visualize_loop(panels, global_orientation, device).await;
     });
 }
 
+/// The core asynchronous loop that runs the interactive visualization.
+///
+/// This function implements the main game loop:
+/// - Clears background and draws title.
+/// - Computes transformed positions applying global rotation.
+/// - Draws all panels and controllers.
+/// - Handles left mouse clicks to flash panels via UDP if controller available.
+/// - Draws instructions and checks for ESC key to exit.
+///
+/// # Arguments
+///
+/// * `panels` - List of all panels including controllers.
+/// * `global_orientation` - Applied as clockwise rotation to layout.
+/// * `device` - Used to create UDP controller for flashing.
 async fn visualize_loop(panels: Vec<PanelInfo>, global_orientation: u16, device: NlDevice) {
-    // Find bounds
+    // Calculate the layout bounds by finding min/max coordinates of all panels,
+    // used for scaling and centering the visualization.
     let min_x = panels.iter().map(|p| p.x).min().unwrap_or(0) as f32;
     let max_x = panels.iter().map(|p| p.x).max().unwrap_or(0) as f32;
     let min_y = panels.iter().map(|p| p.y).min().unwrap_or(0) as f32;
@@ -28,11 +127,12 @@ async fn visualize_loop(panels: Vec<PanelInfo>, global_orientation: u16, device:
     let layout_width = max_x - min_x;
     let layout_height = max_y - min_y;
 
-    // Window configuration
+    // Set fixed window size: 1200x800 pixels for optimal layout display.
     let window_width = 1200.0;
     let window_height = 800.0;
 
-    // Calculate scale to fit layout in window with padding
+    // Calculate uniform scaling factor to fit the layout inside the window with padding,
+    // using the minimum of horizontal and vertical scales to avoid distortion.
     let padding_top = 100.0; // Extra space at top for title
     let padding_bottom = 50.0;
     let padding_sides = 50.0;
@@ -43,7 +143,8 @@ async fn visualize_loop(panels: Vec<PanelInfo>, global_orientation: u16, device:
     let scale_y = available_height / layout_height;
     let scale = scale_x.min(scale_y);
 
-    // Setup Nanoleaf controller for sending commands
+    // Initialize optional UDP controller using device IP and token for flashing panels.
+    // Gracefully handles initialization failure by disabling clicks but continuing render.
     let nl_controller = match crate::nanoleaf::NlUdp::new(&device) {
         Ok(controller) => Some(controller),
         Err(e) => {
@@ -55,7 +156,7 @@ async fn visualize_loop(panels: Vec<PanelInfo>, global_orientation: u16, device:
     loop {
         clear_background(Color::from_rgba(20, 20, 30, 255));
 
-        // Draw title
+        // Draw dynamic title displaying global orientation at top-left with white text.
         draw_text(
             &format!(
                 "Nanoleaf Panel Layout - Global Orientation: {}°",
@@ -67,11 +168,16 @@ async fn visualize_loop(panels: Vec<PanelInfo>, global_orientation: u16, device:
             WHITE,
         );
 
-        // Center the layout in the window horizontally, offset from top
+        // Calculate screen offsets to center the scaled layout horizontally,
+        // vertically centered within available height below title padding.
         let offset_x = (window_width - layout_width * scale) / 2.0;
         let offset_y = padding_top + (available_height - layout_height * scale) / 2.0;
 
-        // First pass: calculate all transformed positions
+        // First pass: Precompute screen positions for all panels.
+        // - Translate to layout-relative coords centered at (0,0)
+        // - Rotate clockwise by -global_orientation radians around origin
+        // - Translate back and scale to screen coordinates with offsets
+        // This enables two-pass rendering: positions first, then drawing with full context.
         let mut transformed_positions = Vec::new();
         for panel in &panels {
             // Apply global orientation rotation to coordinates
@@ -89,7 +195,8 @@ async fn visualize_loop(panels: Vec<PanelInfo>, global_orientation: u16, device:
             transformed_positions.push((screen_x, screen_y));
         }
 
-        // Second pass: draw all panels with access to all positions
+        // Second pass: Draw each panel using transformed positions, providing full layout
+        // context needed for controller attachment calculations.
         for (i, panel) in panels.iter().enumerate() {
             let (screen_x, screen_y) = transformed_positions[i];
             draw_panel(
@@ -102,11 +209,12 @@ async fn visualize_loop(panels: Vec<PanelInfo>, global_orientation: u16, device:
             );
         }
 
-        // Handle mouse clicks
+        // Handle user interaction: On left mouse press with valid controller,
+        // check distance from mouse to each panel center; if within ~1.2x radius, flash it.
         if is_mouse_button_pressed(MouseButton::Left) && nl_controller.is_some() {
             let (mouse_x, mouse_y) = mouse_position();
 
-            // Check which panel was clicked
+            // Scan panels for mouse hit detection, skipping controllers (no side_length).
             for (i, panel) in panels.iter().enumerate() {
                 if panel.shape_type.side_length < 1.0 {
                     continue; // Skip controllers
@@ -124,10 +232,11 @@ async fn visualize_loop(panels: Vec<PanelInfo>, global_orientation: u16, device:
                     side_length
                 };
 
-                // Simple distance check for click detection
+                // Perform radial distance check: mouse within 120% of estimated panel radius
+                // (approximated from side_length and shape: tri/sqrt(3), sq/sqrt(2), else side).
                 let dist = ((mouse_x - screen_x).powi(2) + (mouse_y - screen_y).powi(2)).sqrt();
                 if dist < radius * 1.2 {
-                    // Found the clicked panel - flash it
+                    // Panel hit confirmed: send flash command via UDP controller and exit loop.
                     if let Some(ref controller) = nl_controller {
                         flash_panel(controller, &panels, panel.panel_id);
                     }
@@ -136,7 +245,7 @@ async fn visualize_loop(panels: Vec<PanelInfo>, global_orientation: u16, device:
             }
         }
 
-        // Instructions
+        // Render interaction instructions at bottom-left in smaller gray text.
         draw_text(
             "Press ESC to close | Click panels to flash them",
             10.0,
@@ -153,6 +262,32 @@ async fn visualize_loop(panels: Vec<PanelInfo>, global_orientation: u16, device:
     }
 }
 
+/// Draws a single panel or controller at the specified screen position.
+///
+/// Supports different shape types:
+/// - Light panels (side_length >=1): Polygons (triangles=3 sides, squares=4, hex=6) with colors based on shape ID.
+/// - Controllers (side_length <1): Yellow trapezoids attached to the nearest light panel's edge.
+///
+/// For light panels:
+/// - Vertices calculated from radius, orientation.
+/// - Filled with semi-transparent color matching shape family.
+/// - White outline.
+/// - Panel ID text in center.
+///
+/// For controllers:
+/// - Finds nearest parent panel.
+/// - Determines closest edge.
+/// - Draws trapezoid protruding outward, narrower at tip.
+/// - Outlined and labeled "C".
+///
+/// # Arguments
+///
+/// * `x` - Center x coordinate on screen.
+/// * `y` - Center y coordinate on screen.
+/// * `panel` - The `PanelInfo` to draw.
+/// * `scale` - Scaling factor for sizes.
+/// * `all_panels` - Full list for finding parent for controllers.
+/// * `transformed_positions` - Precomputed screen positions of all panels.
 fn draw_panel(
     x: f32,
     y: f32,
@@ -161,9 +296,10 @@ fn draw_panel(
     all_panels: &[PanelInfo],
     transformed_positions: &[(f32, f32)],
 ) {
-    // Handle controllers specially (they have side_length 0)
+    // Branch for controllers: panels with side_length <1.0 are non-light controllers,
+    // visualized as yellow trapezoids attached to the nearest light panel's edge for realism.
     if panel.shape_type.side_length < 1.0 {
-        // Find the nearest panel to attach to
+        // Select parent light panel: minimum distance to any valid (light) panel center.
         let mut min_dist = f32::MAX;
         let mut nearest_idx = 0;
 
@@ -181,16 +317,17 @@ fn draw_panel(
         let (parent_x, parent_y) = transformed_positions[nearest_idx];
         let parent_panel = &all_panels[nearest_idx];
 
-        // Calculate angle from parent to controller
+        // Determine angular direction (atan2) from parent to controller for aligning with parent edges.
         let dx = x - parent_x;
         let dy = y - parent_y;
         let angle_to_controller = dy.atan2(dx);
 
-        // Get parent shape info
+        // Extract parent's num_sides and scaled side_length for radius and vertex computation.
         let num_sides = parent_panel.shape_type.num_sides();
         let parent_side_length = parent_panel.shape_type.side_length * scale;
 
-        // Calculate parent radius
+        // Compute distance from center to vertex (circumradius) based on shape:
+        // triangle: side / sqrt(3), square: side / sqrt(2), default: side.
         let parent_radius = if num_sides == 3 {
             parent_side_length / f32::sqrt(3.0)
         } else if num_sides == 4 {
@@ -199,7 +336,8 @@ fn draw_panel(
             parent_side_length
         };
 
-        // Find which edge of the parent the controller is closest to
+        // Select closest parent edge: iterate over vertex angles (adjusted by parent orientation),
+        // find minimum angular difference to controller direction using shortest arc distance modulo 2π.
         let parent_orientation = (parent_panel.orientation as f32).to_radians();
         let angle_per_side = 2.0 * PI / num_sides as f32;
 
@@ -216,7 +354,7 @@ fn draw_panel(
             }
         }
 
-        // Calculate the two vertices of the edge
+        // Position the edge endpoints: v1 and v2 at angles from parent orientation + edge index * angle_per_side.
         let v1_angle = parent_orientation + (closest_edge as f32 * angle_per_side);
         let v2_angle = parent_orientation + ((closest_edge + 1) as f32 * angle_per_side);
 
@@ -225,10 +363,11 @@ fn draw_panel(
         let v2_x = parent_x + parent_radius * v2_angle.cos();
         let v2_y = parent_y + parent_radius * v2_angle.sin();
 
-        // Draw trapezoid attached to this edge
+        // Define trapezoid vertices: top matches edge v1-v2, bottom parallel but shorter and offset
+        // perpendicular outward by fixed height; fill with yellow triangles, outline in darker yellow.
         let trapezoid_height = 20.0;
 
-        // Calculate perpendicular direction (outward from parent)
+        // Derive outward normal: vector from center to edge midpoint, normalized for extension.
         let edge_mid_x = (v1_x + v2_x) / 2.0;
         let edge_mid_y = (v1_y + v2_y) / 2.0;
         let perp_dx = edge_mid_x - parent_x;
@@ -237,7 +376,9 @@ fn draw_panel(
         let perp_norm_x = perp_dx / perp_len;
         let perp_norm_y = perp_dy / perp_len;
 
-        // Trapezoid vertices: top edge matches parent edge, bottom edge is narrower
+        // Assemble trapezoid vertices array:
+        // - Top: parent edge endpoints v1, v2
+        // - Bottom: inset towards midpoint by (1-0.6=0.4), extended along perpendicular normal by height=20px
         let narrow_ratio = 0.6; // Bottom edge is 60% of top edge
 
         let vertices = [
@@ -255,7 +396,7 @@ fn draw_panel(
             ),
         ];
 
-        // Draw filled trapezoid
+        // Render filled trapezoid by splitting into two triangles with solid yellow color.
         draw_triangle(
             vertices[0],
             vertices[1],
@@ -269,7 +410,7 @@ fn draw_panel(
             Color::from_rgba(255, 200, 0, 255),
         );
 
-        // Draw outline
+        // Outline trapezoid edges with 2px thick darker yellow lines connecting vertices cyclically.
         for i in 0..vertices.len() {
             let next = (i + 1) % vertices.len();
             draw_line(
@@ -282,7 +423,7 @@ fn draw_panel(
             );
         }
 
-        // Draw "C" label in center of trapezoid
+        // Add 'C' identifier: measure text, center at trapezoid centroid in black 10pt font.
         let text_size = 10.0;
         let text_dims = measure_text("C", None, text_size as u16, 1.0);
         let label_x = (vertices[0].x + vertices[1].x + vertices[2].x + vertices[3].x) / 4.0;
@@ -297,10 +438,11 @@ fn draw_panel(
         return;
     }
 
+    // Light panel rendering: compute polygon sides and scaled side length.
     let num_sides = panel.shape_type.num_sides();
     let side_length = panel.shape_type.side_length * scale;
 
-    // Calculate radius from center to vertex
+    // Calculate circumradius (center to vertex) using geometry formulas per shape type.
     let radius = if num_sides == 3 {
         side_length / f32::sqrt(3.0)
     } else if num_sides == 4 {
@@ -309,7 +451,7 @@ fn draw_panel(
         side_length
     };
 
-    // Calculate vertices
+    // Compute vertex positions: for each side, angle = orientation_rad + i * (2π / n), offset from center by radius.
     let start_angle = (panel.orientation as f32).to_radians();
     let mut vertices = Vec::new();
 
@@ -320,7 +462,7 @@ fn draw_panel(
         vertices.push(Vec2::new(vx, vy));
     }
 
-    // Choose color based on shape type
+    // Select panel fill color by shape ID groups for visual distinction (alpha=200 for transparency).
     let color = match panel.shape_type.id {
         0 | 8 | 9 => Color::from_rgba(255, 100, 100, 200),
         2..=4 => Color::from_rgba(100, 255, 100, 200),
@@ -329,12 +471,12 @@ fn draw_panel(
         _ => Color::from_rgba(150, 150, 150, 200),
     };
 
-    // Draw filled polygon
+    // Fill the convex polygon using triangle fan: vertex[0] to consecutive pairs.
     for i in 1..(num_sides - 1) {
         draw_triangle(vertices[0], vertices[i], vertices[i + 1], color);
     }
 
-    // Draw outline
+    // Draw polygon boundary: connect consecutive vertices with white 2px lines.
     for i in 0..num_sides {
         let next = (i + 1) % num_sides;
         draw_line(
@@ -347,7 +489,7 @@ fn draw_panel(
         );
     }
 
-    // Draw panel ID in center
+    // Render panel ID text: format as string, measure for centering at panel center position.
     let id_text = format!("{}", panel.panel_id);
     let text_size = 16.0;
     let text_dims = measure_text(&id_text, None, text_size as u16, 1.0);
@@ -360,32 +502,45 @@ fn draw_panel(
     );
 }
 
+/// Flashes a specific panel white briefly by sending UDP color updates.
+///
+/// Sets the clicked panel to white (Hwb(359,0,0)) and all other light panels to black (Hwb(0,0,1)).
+/// Updates immediately (transition=1), waits 300ms, then sets all light panels back to black.
+///
+/// Only affects panels with side_length >=1.0 (light panels, skips controllers).
+///
+/// # Arguments
+///
+/// * `controller` - Initialized `NlUdp` instance for sending commands.
+/// * `all_panels` - Full panel list to determine which to color.
+/// * `clicked_panel_id` - ID of the panel to flash white.
 fn flash_panel(
     controller: &crate::nanoleaf::NlUdp,
     all_panels: &[PanelInfo],
     clicked_panel_id: u16,
 ) {
-    // Create color array - white for clicked panel, black for all others
-    // Only include actual light panels (skip controllers with side_length < 1.0)
+    // Construct per-panel Hwb colors for UDP update: white (Hwb::new(359.0, 0.0, 0.0)) for clicked,
+    // black (Hwb::new(0.0, 0.0, 1.0)) for other light panels; exclude controllers from array.
     let colors: Vec<Hwb> = all_panels
         .iter()
         .filter(|panel| panel.shape_type.side_length >= 1.0)
         .map(|panel| {
             if panel.panel_id == clicked_panel_id {
-                Hwb::new(0.0, 1.0, 0.0) // White
+                Hwb::new(359.0, 0.0, 0.0) // White
             } else {
                 Hwb::new(0.0, 0.0, 1.0) // Black
             }
         })
         .collect();
 
-    // Flash on
+    // Send 'on' state: set clicked panel white, others black; immediate transition (duration=1).
     let _ = controller.update_panels(&colors, 1);
 
-    // Brief delay
+    // Sleep 300 milliseconds for visible flash duration.
     thread::sleep(Duration::from_millis(300));
 
-    // Flash off - set all panels to black to return to normal
+    // Reset flash: update all light panels to black, effectively turning off the highlight
+    // (note: this overrides any current effect; in practice, may need to restore original colors for seamless integration).
     let black_colors: Vec<Hwb> = all_panels
         .iter()
         .filter(|panel| panel.shape_type.side_length >= 1.0)

--- a/src/graphical_layout.rs
+++ b/src/graphical_layout.rs
@@ -1,0 +1,395 @@
+use crate::layout_visualizer::PanelInfo;
+use crate::nanoleaf::NlDevice;
+use macroquad::prelude::*;
+use palette::Hwb;
+use std::f32::consts::PI;
+use std::thread;
+use std::time::Duration;
+
+pub fn visualize_graphical(panels: Vec<PanelInfo>, global_orientation: u16, device: NlDevice) {
+    // Run the visualization synchronously
+    pollster::block_on(visualize_async(panels, global_orientation, device));
+}
+
+async fn visualize_async(panels: Vec<PanelInfo>, global_orientation: u16, device: NlDevice) {
+    // Initialize macroquad window
+    macroquad::Window::new("Nanoleaf Panel Layout", async move {
+        visualize_loop(panels, global_orientation, device).await;
+    });
+}
+
+async fn visualize_loop(panels: Vec<PanelInfo>, global_orientation: u16, device: NlDevice) {
+    // Find bounds
+    let min_x = panels.iter().map(|p| p.x).min().unwrap_or(0) as f32;
+    let max_x = panels.iter().map(|p| p.x).max().unwrap_or(0) as f32;
+    let min_y = panels.iter().map(|p| p.y).min().unwrap_or(0) as f32;
+    let max_y = panels.iter().map(|p| p.y).max().unwrap_or(0) as f32;
+
+    let layout_width = max_x - min_x;
+    let layout_height = max_y - min_y;
+
+    // Window configuration
+    let window_width = 1200.0;
+    let window_height = 800.0;
+
+    // Calculate scale to fit layout in window with padding
+    let padding_top = 100.0; // Extra space at top for title
+    let padding_bottom = 50.0;
+    let padding_sides = 50.0;
+    let available_width = window_width - 2.0 * padding_sides;
+    let available_height = window_height - padding_top - padding_bottom;
+
+    let scale_x = available_width / layout_width;
+    let scale_y = available_height / layout_height;
+    let scale = scale_x.min(scale_y);
+
+    // Setup Nanoleaf controller for sending commands
+    let nl_controller = match crate::nanoleaf::NlUdp::new(&device) {
+        Ok(controller) => Some(controller),
+        Err(e) => {
+            eprintln!("Warning: Could not initialize Nanoleaf controller: {}", e);
+            None
+        }
+    };
+
+    loop {
+        clear_background(Color::from_rgba(20, 20, 30, 255));
+
+        // Draw title
+        draw_text(
+            &format!(
+                "Nanoleaf Panel Layout - Global Orientation: {}°",
+                global_orientation
+            ),
+            10.0,
+            30.0,
+            30.0,
+            WHITE,
+        );
+
+        // Center the layout in the window horizontally, offset from top
+        let offset_x = (window_width - layout_width * scale) / 2.0;
+        let offset_y = padding_top + (available_height - layout_height * scale) / 2.0;
+
+        // First pass: calculate all transformed positions
+        let mut transformed_positions = Vec::new();
+        for panel in &panels {
+            // Apply global orientation rotation to coordinates
+            let rel_x = (panel.x as f32 - min_x) - layout_width / 2.0;
+            let rel_y = (panel.y as f32 - min_y) - layout_height / 2.0;
+
+            let angle = -(global_orientation as f32).to_radians(); // Negative for clockwise
+            let rotated_x = rel_x * angle.cos() - rel_y * angle.sin();
+            let rotated_y = rel_x * angle.sin() + rel_y * angle.cos();
+
+            // Convert to screen coordinates
+            let screen_x = offset_x + (rotated_x + layout_width / 2.0) * scale;
+            let screen_y = offset_y + (layout_height / 2.0 - rotated_y) * scale; // Flip Y
+
+            transformed_positions.push((screen_x, screen_y));
+        }
+
+        // Second pass: draw all panels with access to all positions
+        for (i, panel) in panels.iter().enumerate() {
+            let (screen_x, screen_y) = transformed_positions[i];
+            draw_panel(
+                screen_x,
+                screen_y,
+                panel,
+                scale,
+                &panels,
+                &transformed_positions,
+            );
+        }
+
+        // Handle mouse clicks
+        if is_mouse_button_pressed(MouseButton::Left) && nl_controller.is_some() {
+            let (mouse_x, mouse_y) = mouse_position();
+
+            // Check which panel was clicked
+            for (i, panel) in panels.iter().enumerate() {
+                if panel.shape_type.side_length < 1.0 {
+                    continue; // Skip controllers
+                }
+
+                let (screen_x, screen_y) = transformed_positions[i];
+                let num_sides = panel.shape_type.num_sides();
+                let side_length = panel.shape_type.side_length * scale;
+
+                let radius = if num_sides == 3 {
+                    side_length / f32::sqrt(3.0)
+                } else if num_sides == 4 {
+                    side_length / f32::sqrt(2.0)
+                } else {
+                    side_length
+                };
+
+                // Simple distance check for click detection
+                let dist = ((mouse_x - screen_x).powi(2) + (mouse_y - screen_y).powi(2)).sqrt();
+                if dist < radius * 1.2 {
+                    // Found the clicked panel - flash it
+                    if let Some(ref controller) = nl_controller {
+                        flash_panel(controller, &panels, panel.panel_id);
+                    }
+                    break;
+                }
+            }
+        }
+
+        // Instructions
+        draw_text(
+            "Press ESC to close | Click panels to flash them",
+            10.0,
+            window_height - 20.0,
+            20.0,
+            GRAY,
+        );
+
+        if is_key_pressed(KeyCode::Escape) {
+            break;
+        }
+
+        next_frame().await
+    }
+}
+
+fn draw_panel(
+    x: f32,
+    y: f32,
+    panel: &PanelInfo,
+    scale: f32,
+    all_panels: &[PanelInfo],
+    transformed_positions: &[(f32, f32)],
+) {
+    // Handle controllers specially (they have side_length 0)
+    if panel.shape_type.side_length < 1.0 {
+        // Find the nearest panel to attach to
+        let mut min_dist = f32::MAX;
+        let mut nearest_idx = 0;
+
+        for (i, other_panel) in all_panels.iter().enumerate() {
+            if other_panel.shape_type.side_length >= 1.0 {
+                let (other_x, other_y) = transformed_positions[i];
+                let dist = ((x - other_x).powi(2) + (y - other_y).powi(2)).sqrt();
+                if dist < min_dist {
+                    min_dist = dist;
+                    nearest_idx = i;
+                }
+            }
+        }
+
+        let (parent_x, parent_y) = transformed_positions[nearest_idx];
+        let parent_panel = &all_panels[nearest_idx];
+
+        // Calculate angle from parent to controller
+        let dx = x - parent_x;
+        let dy = y - parent_y;
+        let angle_to_controller = dy.atan2(dx);
+
+        // Get parent shape info
+        let num_sides = parent_panel.shape_type.num_sides();
+        let parent_side_length = parent_panel.shape_type.side_length * scale;
+
+        // Calculate parent radius
+        let parent_radius = if num_sides == 3 {
+            parent_side_length / f32::sqrt(3.0)
+        } else if num_sides == 4 {
+            parent_side_length / f32::sqrt(2.0)
+        } else {
+            parent_side_length
+        };
+
+        // Find which edge of the parent the controller is closest to
+        let parent_orientation = (parent_panel.orientation as f32).to_radians();
+        let angle_per_side = 2.0 * PI / num_sides as f32;
+
+        let mut closest_edge = 0;
+        let mut min_angle_diff = f32::MAX;
+
+        for i in 0..num_sides {
+            let vertex_angle = parent_orientation + (i as f32 * angle_per_side);
+            let angle_diff = ((angle_to_controller - vertex_angle).abs() % (2.0 * PI))
+                .min((2.0 * PI) - ((angle_to_controller - vertex_angle).abs() % (2.0 * PI)));
+            if angle_diff < min_angle_diff {
+                min_angle_diff = angle_diff;
+                closest_edge = i;
+            }
+        }
+
+        // Calculate the two vertices of the edge
+        let v1_angle = parent_orientation + (closest_edge as f32 * angle_per_side);
+        let v2_angle = parent_orientation + ((closest_edge + 1) as f32 * angle_per_side);
+
+        let v1_x = parent_x + parent_radius * v1_angle.cos();
+        let v1_y = parent_y + parent_radius * v1_angle.sin();
+        let v2_x = parent_x + parent_radius * v2_angle.cos();
+        let v2_y = parent_y + parent_radius * v2_angle.sin();
+
+        // Draw trapezoid attached to this edge
+        let trapezoid_height = 20.0;
+
+        // Calculate perpendicular direction (outward from parent)
+        let edge_mid_x = (v1_x + v2_x) / 2.0;
+        let edge_mid_y = (v1_y + v2_y) / 2.0;
+        let perp_dx = edge_mid_x - parent_x;
+        let perp_dy = edge_mid_y - parent_y;
+        let perp_len = (perp_dx * perp_dx + perp_dy * perp_dy).sqrt();
+        let perp_norm_x = perp_dx / perp_len;
+        let perp_norm_y = perp_dy / perp_len;
+
+        // Trapezoid vertices: top edge matches parent edge, bottom edge is narrower
+        let narrow_ratio = 0.6; // Bottom edge is 60% of top edge
+
+        let vertices = [
+            Vec2::new(v1_x, v1_y), // Top left (on parent edge)
+            Vec2::new(v2_x, v2_y), // Top right (on parent edge)
+            // Bottom right (narrower, extended outward)
+            Vec2::new(
+                v2_x + perp_norm_x * trapezoid_height - (v2_x - edge_mid_x) * (1.0 - narrow_ratio),
+                v2_y + perp_norm_y * trapezoid_height - (v2_y - edge_mid_y) * (1.0 - narrow_ratio),
+            ),
+            // Bottom left (narrower, extended outward)
+            Vec2::new(
+                v1_x + perp_norm_x * trapezoid_height - (v1_x - edge_mid_x) * (1.0 - narrow_ratio),
+                v1_y + perp_norm_y * trapezoid_height - (v1_y - edge_mid_y) * (1.0 - narrow_ratio),
+            ),
+        ];
+
+        // Draw filled trapezoid
+        draw_triangle(
+            vertices[0],
+            vertices[1],
+            vertices[2],
+            Color::from_rgba(255, 200, 0, 255),
+        );
+        draw_triangle(
+            vertices[0],
+            vertices[2],
+            vertices[3],
+            Color::from_rgba(255, 200, 0, 255),
+        );
+
+        // Draw outline
+        for i in 0..vertices.len() {
+            let next = (i + 1) % vertices.len();
+            draw_line(
+                vertices[i].x,
+                vertices[i].y,
+                vertices[next].x,
+                vertices[next].y,
+                2.0,
+                Color::from_rgba(200, 150, 0, 255),
+            );
+        }
+
+        // Draw "C" label in center of trapezoid
+        let text_size = 10.0;
+        let text_dims = measure_text("C", None, text_size as u16, 1.0);
+        let label_x = (vertices[0].x + vertices[1].x + vertices[2].x + vertices[3].x) / 4.0;
+        let label_y = (vertices[0].y + vertices[1].y + vertices[2].y + vertices[3].y) / 4.0;
+        draw_text(
+            "C",
+            label_x - text_dims.width / 2.0,
+            label_y + text_size / 3.0,
+            text_size,
+            BLACK,
+        );
+        return;
+    }
+
+    let num_sides = panel.shape_type.num_sides();
+    let side_length = panel.shape_type.side_length * scale;
+
+    // Calculate radius from center to vertex
+    let radius = if num_sides == 3 {
+        side_length / f32::sqrt(3.0)
+    } else if num_sides == 4 {
+        side_length / f32::sqrt(2.0)
+    } else {
+        side_length
+    };
+
+    // Calculate vertices
+    let start_angle = (panel.orientation as f32).to_radians();
+    let mut vertices = Vec::new();
+
+    for i in 0..num_sides {
+        let angle = start_angle + (i as f32 * 2.0 * PI / num_sides as f32);
+        let vx = x + radius * angle.cos();
+        let vy = y + radius * angle.sin();
+        vertices.push(Vec2::new(vx, vy));
+    }
+
+    // Choose color based on shape type
+    let color = match panel.shape_type.id {
+        0 | 8 | 9 => Color::from_rgba(255, 100, 100, 200),
+        2..=4 => Color::from_rgba(100, 255, 100, 200),
+        7 | 14 | 15 => Color::from_rgba(100, 150, 255, 200),
+        30..=32 => Color::from_rgba(255, 255, 100, 200),
+        _ => Color::from_rgba(150, 150, 150, 200),
+    };
+
+    // Draw filled polygon
+    for i in 1..(num_sides - 1) {
+        draw_triangle(vertices[0], vertices[i], vertices[i + 1], color);
+    }
+
+    // Draw outline
+    for i in 0..num_sides {
+        let next = (i + 1) % num_sides;
+        draw_line(
+            vertices[i].x,
+            vertices[i].y,
+            vertices[next].x,
+            vertices[next].y,
+            2.0,
+            WHITE,
+        );
+    }
+
+    // Draw panel ID in center
+    let id_text = format!("{}", panel.panel_id);
+    let text_size = 16.0;
+    let text_dims = measure_text(&id_text, None, text_size as u16, 1.0);
+    draw_text(
+        &id_text,
+        x - text_dims.width / 2.0,
+        y + text_size / 3.0,
+        text_size,
+        BLACK,
+    );
+}
+
+fn flash_panel(
+    controller: &crate::nanoleaf::NlUdp,
+    all_panels: &[PanelInfo],
+    clicked_panel_id: u16,
+) {
+    // Create color array - white for clicked panel, black for all others
+    // Only include actual light panels (skip controllers with side_length < 1.0)
+    let colors: Vec<Hwb> = all_panels
+        .iter()
+        .filter(|panel| panel.shape_type.side_length >= 1.0)
+        .map(|panel| {
+            if panel.panel_id == clicked_panel_id {
+                Hwb::new(0.0, 1.0, 0.0) // White
+            } else {
+                Hwb::new(0.0, 0.0, 1.0) // Black
+            }
+        })
+        .collect();
+
+    // Flash on
+    let _ = controller.update_panels(&colors, 1);
+
+    // Brief delay
+    thread::sleep(Duration::from_millis(300));
+
+    // Flash off - set all panels to black to return to normal
+    let black_colors: Vec<Hwb> = all_panels
+        .iter()
+        .filter(|panel| panel.shape_type.side_length >= 1.0)
+        .map(|_| Hwb::new(0.0, 0.0, 1.0))
+        .collect();
+    let _ = controller.update_panels(&black_colors, 1);
+}

--- a/src/layout_visualizer.rs
+++ b/src/layout_visualizer.rs
@@ -9,6 +9,11 @@ pub struct ShapeType {
 }
 
 impl ShapeType {
+    /// Constructs a `ShapeType` from Nanoleaf's internal shape ID.
+    ///
+    /// Maps known IDs to panel types like triangles, squares, hexagons, controllers, and special shapes (e.g., Elements, Lines).
+    /// Provides `side_length` approximation for rendering and `name` for display.
+    /// Unknown IDs default to generic square with side 100.0.
     pub fn from_id(id: u64) -> Self {
         match id {
             0 => ShapeType {
@@ -119,6 +124,11 @@ impl ShapeType {
         }
     }
 
+    /// Returns the number of sides for this shape type, useful for polygon rendering.
+    ///
+    /// - 3 for triangles (IDs 0,8,9)
+    /// - 4 for squares and most others (default)
+    /// - 6 for hexagons (IDs 7,14,15)
     pub fn num_sides(&self) -> usize {
         match self.id {
             0 | 8 | 9 => 3,   // Triangles
@@ -138,6 +148,19 @@ pub struct PanelInfo {
     pub shape_type: ShapeType,
 }
 
+/// Parses the "positionData" array from Nanoleaf's panel layout JSON response.
+///
+/// Expects array of objects with "panelId" (u16), "x"/"y" (i16), "o" (orientation u16), "shapeType" (u64 ID).
+/// Converts coordinates and creates `PanelInfo` for each, using `ShapeType::from_id`.
+/// Defaults missing fields to 0.
+///
+/// # Arguments
+///
+/// * `layout_json` - serde_json::Value typically from /api/v1/panelLayout endpoint.
+///
+/// # Returns
+///
+/// `Result<Vec<PanelInfo>>` - List of parsed panel positions and types, or error if no positionData array.
 pub fn parse_layout(layout_json: &Value) -> Result<Vec<PanelInfo>> {
     let position_data = layout_json["positionData"]
         .as_array()
@@ -165,6 +188,12 @@ pub fn parse_layout(layout_json: &Value) -> Result<Vec<PanelInfo>> {
     Ok(panels)
 }
 
+/// Prints a textual summary and table of the Nanoleaf panel layout to stdout.
+///
+/// Computes bounds (min/max x,y), displays global orientation, and tabulates:
+/// Panel ID, Shape Type name, X/Y positions, Orientation (degrees), Side length.
+///
+/// Intended for CLI 'dump layout' command output. Suggests graphical alt for visual rep.
 pub fn visualize_layout(panels: &[PanelInfo], global_orientation: u16) {
     if panels.is_empty() {
         println!("No panels to visualize");

--- a/src/layout_visualizer.rs
+++ b/src/layout_visualizer.rs
@@ -1,0 +1,203 @@
+use anyhow::Result;
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy)]
+pub struct ShapeType {
+    pub id: u64,
+    pub name: &'static str,
+    pub side_length: f32,
+}
+
+impl ShapeType {
+    pub fn from_id(id: u64) -> Self {
+        match id {
+            0 => ShapeType {
+                id,
+                name: "Triangle",
+                side_length: 150.0,
+            },
+            1 => ShapeType {
+                id,
+                name: "Rhythm",
+                side_length: 0.0,
+            },
+            2 => ShapeType {
+                id,
+                name: "Square",
+                side_length: 100.0,
+            },
+            3 => ShapeType {
+                id,
+                name: "Control Square Master",
+                side_length: 100.0,
+            },
+            4 => ShapeType {
+                id,
+                name: "Control Square Passive",
+                side_length: 100.0,
+            },
+            7 => ShapeType {
+                id,
+                name: "Hexagon (Shapes)",
+                side_length: 67.0,
+            },
+            8 => ShapeType {
+                id,
+                name: "Triangle (Shapes)",
+                side_length: 134.0,
+            },
+            9 => ShapeType {
+                id,
+                name: "Mini Triangle (Shapes)",
+                side_length: 67.0,
+            },
+            12 => ShapeType {
+                id,
+                name: "Shapes Controller",
+                side_length: 0.0,
+            },
+            14 => ShapeType {
+                id,
+                name: "Elements Hexagons",
+                side_length: 134.0,
+            },
+            15 => ShapeType {
+                id,
+                name: "Elements Hexagons - Corner",
+                side_length: 45.75,
+            },
+            16 => ShapeType {
+                id,
+                name: "Lines Connector",
+                side_length: 11.0,
+            },
+            17 => ShapeType {
+                id,
+                name: "Light Lines",
+                side_length: 154.0,
+            },
+            18 => ShapeType {
+                id,
+                name: "Light Lines - Single Zone",
+                side_length: 77.0,
+            },
+            19 => ShapeType {
+                id,
+                name: "Controller Cap",
+                side_length: 11.0,
+            },
+            20 => ShapeType {
+                id,
+                name: "Power Connector",
+                side_length: 11.0,
+            },
+            29 => ShapeType {
+                id,
+                name: "Nanoleaf 4D Lightstrip",
+                side_length: 50.0,
+            },
+            30 => ShapeType {
+                id,
+                name: "Skylight Panel",
+                side_length: 180.0,
+            },
+            31 => ShapeType {
+                id,
+                name: "Skylight Controller Primary",
+                side_length: 180.0,
+            },
+            32 => ShapeType {
+                id,
+                name: "Skylight Controller Passive Mode",
+                side_length: 180.0,
+            },
+            _ => ShapeType {
+                id,
+                name: "Unknown",
+                side_length: 100.0,
+            },
+        }
+    }
+
+    pub fn num_sides(&self) -> usize {
+        match self.id {
+            0 | 8 | 9 => 3,   // Triangles
+            2..=4 => 4,       // Squares
+            7 | 14 | 15 => 6, // Hexagons
+            _ => 4,           // Default to square
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PanelInfo {
+    pub panel_id: u16,
+    pub x: i16,
+    pub y: i16,
+    pub orientation: u16,
+    pub shape_type: ShapeType,
+}
+
+pub fn parse_layout(layout_json: &Value) -> Result<Vec<PanelInfo>> {
+    let position_data = layout_json["positionData"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("No positionData in layout"))?;
+
+    let mut panels = Vec::new();
+
+    for panel_data in position_data {
+        let panel_id = panel_data["panelId"].as_u64().unwrap_or(0) as u16;
+        let x = panel_data["x"].as_i64().unwrap_or(0) as i16;
+        let y = panel_data["y"].as_i64().unwrap_or(0) as i16;
+        let orientation = panel_data["o"].as_u64().unwrap_or(0) as u16;
+        let shape_type_id = panel_data["shapeType"].as_u64().unwrap_or(0);
+        let shape_type = ShapeType::from_id(shape_type_id);
+
+        panels.push(PanelInfo {
+            panel_id,
+            x,
+            y,
+            orientation,
+            shape_type,
+        });
+    }
+
+    Ok(panels)
+}
+
+pub fn visualize_layout(panels: &[PanelInfo], global_orientation: u16) {
+    if panels.is_empty() {
+        println!("No panels to visualize");
+        return;
+    }
+
+    // Find bounds
+    let min_x = panels.iter().map(|p| p.x).min().unwrap();
+    let max_x = panels.iter().map(|p| p.x).max().unwrap();
+    let min_y = panels.iter().map(|p| p.y).min().unwrap();
+    let max_y = panels.iter().map(|p| p.y).max().unwrap();
+
+    println!("\n=== Panel Layout Visualization ===");
+    println!("Global Orientation: {} degrees", global_orientation);
+    println!("Bounds: X[{}, {}], Y[{}, {}]", min_x, max_x, min_y, max_y);
+    println!("\nPanels:");
+    println!(
+        "{:<8} {:<30} {:<10} {:<10} {:<12} {:<12}",
+        "Panel ID", "Shape Type", "X", "Y", "Orientation", "Side Length"
+    );
+    println!("{}", "-".repeat(100));
+
+    for panel in panels {
+        println!(
+            "{:<8} {:<30} {:<10} {:<10} {:<12} {:<12.1}",
+            panel.panel_id,
+            panel.shape_type.name,
+            panel.x,
+            panel.y,
+            format!("{}°", panel.orientation),
+            panel.shape_type.side_length
+        );
+    }
+
+    println!("\nNote: Use 'dump layout-graphical' for a visual representation");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,10 +16,21 @@ mod ssdp;
 mod utils;
 mod visualizer;
 
+/// The main entry point of the Audioleaf application.
+///
+/// This function blocks on the asynchronous main logic using `pollster::block_on`.
+/// It sets up panic handling and parses CLI options before delegating to `main_async`.
 fn main() -> Result<()> {
     pollster::block_on(main_async())
 }
 
+/// Asynchronous main logic of the Audioleaf application.
+///
+/// Parses CLI options and handles different modes:
+/// - Dump commands (layout, palettes, info, graphical layout) without TUI.
+/// - Normal mode: loads or discovers Nanoleaf device, sets up config, runs TUI visualizer/effect selector.
+///
+/// Ensures device is ready (powered on, brightness set) before running the app.
 async fn main_async() -> Result<()> {
     panic::register_backtrace_panic_handler();
     let cli_options = config::CliOptions::parse();
@@ -81,6 +92,24 @@ async fn main_async() -> Result<()> {
     Ok(())
 }
 
+/// Handles 'dump' subcommands to display Nanoleaf device information or configuration without launching the TUI.
+///
+/// Supported dump types:
+/// - `Layout`: Fetches and prints panel layout data and global orientation.
+/// - `Palettes`: Lists all predefined color palettes available in the application.
+/// - `LayoutGraphical`: Renders an interactive graphical visualization of the panel layout using macroquad.
+/// - `Info`: Retrieves and prints basic device information from the /api/v1/ endpoint.
+///
+/// In all cases except `Palettes`, it connects to a known device or uses CLI-specified name.
+///
+/// # Arguments
+///
+/// * `dump_type` - Specifies which type of information to dump.
+/// * `cli_options` - Parsed CLI options including config paths and device name.
+///
+/// # Errors
+///
+/// Returns `anyhow::Error` for issues like missing devices file, connection failures, or JSON parsing errors.
 async fn handle_dump_command(
     dump_type: &config::DumpType,
     cli_options: &config::CliOptions,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod event_handler;
 mod graphical_layout;
 mod layout_visualizer;
 mod nanoleaf;
+mod now_playing;
 mod palettes;
 mod panic;
 mod processing;
@@ -145,6 +146,8 @@ async fn handle_dump_command(
             println!("Panel Layout Information for: {}", nl_device.name);
             println!("Device IP: {}", nl_device.ip);
 
+            nl_device.ensure_device_ready()?;
+
             let layout = nl_device.get_panel_layout()?;
             let orientation = nl_device.get_global_orientation()?;
             let global_orientation = orientation["value"].as_u64().unwrap_or(0) as u16;
@@ -159,14 +162,20 @@ async fn handle_dump_command(
             println!("\n=== Raw Global Orientation JSON ===");
             println!("{}", serde_json::to_string_pretty(&orientation)?);
 
+            nl_device.set_state(Some(false), Some(0))?;
             Ok(())
         }
         config::DumpType::Palettes => {
             println!("Available Color Palettes:\n");
-            let palette_names = palettes::get_palette_names();
+            let mut palette_names = palettes::get_palette_names();
+            palette_names.sort();
             for name in palette_names {
-                let hues = palettes::get_palette(&name).unwrap();
-                println!("  {} = {:?}", name, hues);
+                let colors = palettes::get_palette(&name).unwrap();
+                let color_strs: Vec<String> = colors
+                    .iter()
+                    .map(|[r, g, b]| format!("[{}, {}, {}]", r, g, b))
+                    .collect();
+                println!("  {} = [{}]", name, color_strs.join(", "));
             }
             Ok(())
         }
@@ -197,6 +206,10 @@ async fn handle_dump_command(
                 )?
             };
 
+            nl_device.ensure_device_ready()?;
+            // Request UDP control so panel flash commands work
+            nl_device.request_udp_control()?;
+
             let layout = nl_device.get_panel_layout()?;
             let orientation = nl_device.get_global_orientation()?;
             let global_orientation = orientation["value"].as_u64().unwrap_or(0) as u16;
@@ -204,8 +217,9 @@ async fn handle_dump_command(
             let panels = layout_visualizer::parse_layout(&layout)?;
 
             // Call the graphical visualizer - it has its own macroquad::main wrapper
-            graphical_layout::visualize_graphical(panels, global_orientation, nl_device);
+            graphical_layout::visualize_graphical(panels, global_orientation, nl_device.clone());
 
+            nl_device.set_state(Some(false), Some(0))?;
             Ok(())
         }
         config::DumpType::Info => {
@@ -237,10 +251,14 @@ async fn handle_dump_command(
 
             println!("Device Information for: {}", nl_device.name);
             println!("Device IP: {}", nl_device.ip);
+
+            nl_device.ensure_device_ready()?;
+
             println!("\n=== Device Info (from /api/v1/) ===");
             let info = nl_device.get_device_info()?;
             println!("{}", serde_json::to_string_pretty(&info)?);
 
+            nl_device.set_state(Some(false), Some(0))?;
             Ok(())
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ mod audio;
 mod config;
 mod constants;
 mod event_handler;
+mod graphical_layout;
+mod layout_visualizer;
 mod nanoleaf;
 mod palettes;
 mod panic;
@@ -15,13 +17,25 @@ mod utils;
 mod visualizer;
 
 fn main() -> Result<()> {
+    pollster::block_on(main_async())
+}
+
+async fn main_async() -> Result<()> {
     panic::register_backtrace_panic_handler();
+    let cli_options = config::CliOptions::parse();
+
+    // Handle dump commands separately - they don't need TUI
+    if let Some(config::Command::Dump { dump_type }) = &cli_options.command {
+        return handle_dump_command(dump_type, &cli_options).await;
+    }
+
     let config::CliOptions {
         config_file_path,
         devices_file_path,
         device_name,
         add_new,
-    } = config::CliOptions::parse();
+        ..
+    } = cli_options;
     let ((config_file_path, config_file_exists), (devices_file_path, devices_file_exists)) =
         config::resolve_paths(config_file_path, devices_file_path)?;
     let (nl_device, tui_config, visualizer_config) = if !add_new && devices_file_exists {
@@ -56,9 +70,149 @@ fn main() -> Result<()> {
         config.write_to_file(&config_file_path)?;
         (nl_device, config.tui_config, config.visualizer_config)
     };
+
+    // Ensure device is powered on and has brightness set
+    nl_device.ensure_device_ready()?;
+
     let mut app = app::App::new(nl_device, tui_config, visualizer_config)?;
     let mut terminal = utils::init_tui()?;
     app.run(&mut terminal)?;
     utils::destroy_tui()?;
     Ok(())
+}
+
+async fn handle_dump_command(
+    dump_type: &config::DumpType,
+    cli_options: &config::CliOptions,
+) -> Result<()> {
+    match dump_type {
+        config::DumpType::Layout => {
+            // Need to connect to device for layout
+            let ((config_file_path, config_file_exists), (devices_file_path, devices_file_exists)) =
+                config::resolve_paths(
+                    cli_options.config_file_path.clone(),
+                    cli_options.devices_file_path.clone(),
+                )?;
+
+            if !devices_file_exists {
+                anyhow::bail!("No devices file found. Please add a device first.");
+            }
+
+            let nl_device = if config_file_exists {
+                let config = config::Config::parse_from_file(&config_file_path)?;
+                let name_to_search = if cli_options.device_name.is_some() {
+                    &cli_options.device_name
+                } else {
+                    &config.default_nl_device_name
+                };
+                nanoleaf::NlDevice::find_in_file(&devices_file_path, name_to_search.as_deref())?
+            } else {
+                nanoleaf::NlDevice::find_in_file(
+                    &devices_file_path,
+                    cli_options.device_name.as_deref(),
+                )?
+            };
+
+            println!("Panel Layout Information for: {}", nl_device.name);
+            println!("Device IP: {}", nl_device.ip);
+
+            let layout = nl_device.get_panel_layout()?;
+            let orientation = nl_device.get_global_orientation()?;
+            let global_orientation = orientation["value"].as_u64().unwrap_or(0) as u16;
+
+            // Parse and visualize the layout
+            let panels = layout_visualizer::parse_layout(&layout)?;
+            layout_visualizer::visualize_layout(&panels, global_orientation);
+
+            println!("\n=== Raw Panel Layout JSON ===");
+            println!("{}", serde_json::to_string_pretty(&layout)?);
+
+            println!("\n=== Raw Global Orientation JSON ===");
+            println!("{}", serde_json::to_string_pretty(&orientation)?);
+
+            Ok(())
+        }
+        config::DumpType::Palettes => {
+            println!("Available Color Palettes:\n");
+            let palette_names = palettes::get_palette_names();
+            for name in palette_names {
+                let hues = palettes::get_palette(&name).unwrap();
+                println!("  {} = {:?}", name, hues);
+            }
+            Ok(())
+        }
+        config::DumpType::LayoutGraphical => {
+            // Need to connect to device for layout
+            let ((config_file_path, config_file_exists), (devices_file_path, devices_file_exists)) =
+                config::resolve_paths(
+                    cli_options.config_file_path.clone(),
+                    cli_options.devices_file_path.clone(),
+                )?;
+
+            if !devices_file_exists {
+                anyhow::bail!("No devices file found. Please add a device first.");
+            }
+
+            let nl_device = if config_file_exists {
+                let config = config::Config::parse_from_file(&config_file_path)?;
+                let name_to_search = if cli_options.device_name.is_some() {
+                    &cli_options.device_name
+                } else {
+                    &config.default_nl_device_name
+                };
+                nanoleaf::NlDevice::find_in_file(&devices_file_path, name_to_search.as_deref())?
+            } else {
+                nanoleaf::NlDevice::find_in_file(
+                    &devices_file_path,
+                    cli_options.device_name.as_deref(),
+                )?
+            };
+
+            let layout = nl_device.get_panel_layout()?;
+            let orientation = nl_device.get_global_orientation()?;
+            let global_orientation = orientation["value"].as_u64().unwrap_or(0) as u16;
+
+            let panels = layout_visualizer::parse_layout(&layout)?;
+
+            // Call the graphical visualizer - it has its own macroquad::main wrapper
+            graphical_layout::visualize_graphical(panels, global_orientation, nl_device);
+
+            Ok(())
+        }
+        config::DumpType::Info => {
+            // Need to connect to device for info
+            let ((config_file_path, config_file_exists), (devices_file_path, devices_file_exists)) =
+                config::resolve_paths(
+                    cli_options.config_file_path.clone(),
+                    cli_options.devices_file_path.clone(),
+                )?;
+
+            if !devices_file_exists {
+                anyhow::bail!("No devices file found. Please add a device first.");
+            }
+
+            let nl_device = if config_file_exists {
+                let config = config::Config::parse_from_file(&config_file_path)?;
+                let name_to_search = if cli_options.device_name.is_some() {
+                    &cli_options.device_name
+                } else {
+                    &config.default_nl_device_name
+                };
+                nanoleaf::NlDevice::find_in_file(&devices_file_path, name_to_search.as_deref())?
+            } else {
+                nanoleaf::NlDevice::find_in_file(
+                    &devices_file_path,
+                    cli_options.device_name.as_deref(),
+                )?
+            };
+
+            println!("Device Information for: {}", nl_device.name);
+            println!("Device IP: {}", nl_device.ip);
+            println!("\n=== Device Info (from /api/v1/) ===");
+            let info = nl_device.get_device_info()?;
+            println!("{}", serde_json::to_string_pretty(&info)?);
+
+            Ok(())
+        }
+    }
 }

--- a/src/nanoleaf.rs
+++ b/src/nanoleaf.rs
@@ -2,8 +2,8 @@ use crate::{
     config::{Axis, Sort},
     constants, utils,
 };
-use anyhow::{bail, Result};
-use palette::{FromColor, Hsv, Srgb};
+use anyhow::{Result, bail};
+use palette::{FromColor, Hsv, Oklch, Srgb};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::{
@@ -19,7 +19,7 @@ pub struct NlEffect {
     pub palette: Vec<Srgb<u8>>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NlDevice {
     pub name: String,
     pub ip: Ipv4Addr,
@@ -219,24 +219,18 @@ impl NlDevice {
         let is_on = info["state"]["on"]["value"].as_bool().unwrap_or(true);
         let brightness = info["state"]["brightness"]["value"].as_u64().unwrap_or(100) as u8;
 
-        let mut needs_power = false;
-        let mut needs_brightness = false;
+        let needs_power = !is_on;
+        let needs_brightness = brightness != 100;
 
-        if !is_on {
+        if needs_power {
             eprintln!("Device is off. Turning on...");
-            needs_power = true;
         }
-
-        if brightness == 0 {
-            eprintln!("Device brightness is 0. Setting to 100...");
-            needs_brightness = true;
+        if needs_brightness {
+            eprintln!("Device brightness is {}. Setting to 100...", brightness);
         }
 
         if needs_power || needs_brightness {
-            self.set_state(
-                if needs_power { Some(true) } else { None },
-                if needs_brightness { Some(100) } else { None },
-            )?;
+            self.set_state(if needs_power { Some(true) } else { None }, Some(100))?;
             // Give the device a moment to respond to the state change
             std::thread::sleep(std::time::Duration::from_millis(500));
         }
@@ -528,7 +522,7 @@ impl NlUdp {
         (rotated_x, rotated_y)
     }
 
-    pub fn update_panels(&self, colors: &[palette::Hwb], trans_time: i16) -> Result<()> {
+    pub fn update_panels(&self, colors: &[Oklch], trans_time: u16) -> Result<()> {
         let mut buf = vec![0; 8 * self.panels.len() + 2];
         (buf[0], buf[1]) = utils::split_into_bytes(self.panels.len() as u16);
         for (i, color) in colors.iter().enumerate() {
@@ -537,7 +531,7 @@ impl NlUdp {
                 green: g,
                 blue: b,
                 ..
-            } = palette::Srgb::from_color(*color).into_format::<u8>();
+            } = Srgb::from_color(*color).into_format::<u8>();
             let offset = 8 * i + 2;
             (buf[offset], buf[offset + 1]) = utils::split_into_bytes(self.panels[i].id);
             (
@@ -546,14 +540,8 @@ impl NlUdp {
                 buf[offset + 4],
                 buf[offset + 5],
             ) = (r, g, b, 0);
-            // Convert i16 to bytes (supporting -1 for instant transition)
-            // trans_time is in units of 100ms: 1 = 100ms, 2 = 200ms, -1 = instant
-            let trans_time_u16 = if trans_time == -1 {
-                0xFFFF // -1 as u16 (two's complement)
-            } else {
-                trans_time as u16
-            };
-            (buf[offset + 6], buf[offset + 7]) = utils::split_into_bytes(trans_time_u16);
+            // trans_time is in units of 100ms: 0 = instant, 1 = 100ms, 2 = 200ms
+            (buf[offset + 6], buf[offset + 7]) = utils::split_into_bytes(trans_time);
         }
         self.socket.send(&buf)?;
 

--- a/src/nanoleaf.rs
+++ b/src/nanoleaf.rs
@@ -36,12 +36,33 @@ struct NlDevices {
 }
 
 impl From<Vec<NlDevice>> for NlDevices {
+    /// Wraps a vector of devices into the TOML-serializable NlDevices struct.
+    ///
+    /// Used for saving/loading multiple known devices from nl_devices.toml file.
     fn from(nl_devices: Vec<NlDevice>) -> Self {
         NlDevices { nl_devices }
     }
 }
 
 impl NlDevice {
+    /// Creates a new `NlDevice` instance for a given IP address.
+    ///
+    /// Performs API calls to:
+    /// - Obtain auth token via POST /api/v1/new (requires device in pairing mode).
+    /// - Fetch device name from GET /api/v1/{token}.
+    /// - Get current effect name from GET /effects/select, mapping special names to None.
+    ///
+    /// # Arguments
+    ///
+    /// * `ip` - Local IPv4 address of the Nanoleaf device.
+    ///
+    /// # Returns
+    ///
+    /// `Result<NlDevice>` with name, ip, token, optional cur_effect_name.
+    ///
+    /// # Errors
+    ///
+    /// From HTTP requests or JSON parsing; bails on connection failure.
     pub fn new(ip: Ipv4Addr) -> Result<Self> {
         let token = Self::get_token(&ip)?;
         let name = Self::get_name(&ip, &token)?;
@@ -101,6 +122,18 @@ impl NlDevice {
         }
     }
 
+    /// Retrieves the panel layout configuration from the device API.
+    ///
+    /// GET /api/v1/{token}/panelLayout/layout returns JSON with "positionData" array of panel positions/shapes.
+    /// Used for layout visualization and panel sorting/indexing in UDP.
+    ///
+    /// # Returns
+    ///
+    /// `Result<serde_json::Value>` - Raw JSON response.
+    ///
+    /// # Errors
+    ///
+    /// HTTP or parsing errors, bails on connection fail.
     pub fn get_panel_layout(&self) -> Result<serde_json::Value> {
         let Ok(res) = utils::request_get(&format!(
             "http://{}:{}/api/v1/{}/panelLayout/layout",

--- a/src/nanoleaf.rs
+++ b/src/nanoleaf.rs
@@ -101,7 +101,7 @@ impl NlDevice {
         }
     }
 
-    pub fn get_panels(&self) -> Result<Vec<Panel>> {
+    pub fn get_panel_layout(&self) -> Result<serde_json::Value> {
         let Ok(res) = utils::request_get(&format!(
             "http://{}:{}/api/v1/{}/panelLayout/layout",
             self.ip,
@@ -111,6 +111,108 @@ impl NlDevice {
             bail!(utils::generate_connection_error_msg(&self.ip));
         };
         let res_json: serde_json::Value = serde_json::from_str(&res)?;
+        Ok(res_json)
+    }
+
+    pub fn get_global_orientation(&self) -> Result<serde_json::Value> {
+        let Ok(res) = utils::request_get(&format!(
+            "http://{}:{}/api/v1/{}/panelLayout/globalOrientation",
+            self.ip,
+            constants::NL_API_PORT,
+            self.token
+        )) else {
+            bail!(utils::generate_connection_error_msg(&self.ip));
+        };
+        let res_json: serde_json::Value = serde_json::from_str(&res)?;
+        Ok(res_json)
+    }
+
+    pub fn get_device_info(&self) -> Result<serde_json::Value> {
+        let Ok(res) = utils::request_get(&format!(
+            "http://{}:{}/api/v1/{}/",
+            self.ip,
+            constants::NL_API_PORT,
+            self.token
+        )) else {
+            bail!(utils::generate_connection_error_msg(&self.ip));
+        };
+        let res_json: serde_json::Value = serde_json::from_str(&res)?;
+        Ok(res_json)
+    }
+
+    pub fn set_state(&self, power_on: Option<bool>, brightness: Option<u8>) -> Result<()> {
+        let mut state = serde_json::Map::new();
+
+        if let Some(on) = power_on {
+            let mut on_obj = serde_json::Map::new();
+            on_obj.insert("value".to_string(), serde_json::Value::Bool(on));
+            state.insert("on".to_string(), serde_json::Value::Object(on_obj));
+        }
+
+        if let Some(brightness_val) = brightness {
+            let mut brightness_obj = serde_json::Map::new();
+            brightness_obj.insert(
+                "value".to_string(),
+                serde_json::Value::Number(brightness_val.into()),
+            );
+            state.insert(
+                "brightness".to_string(),
+                serde_json::Value::Object(brightness_obj),
+            );
+        }
+
+        if state.is_empty() {
+            return Ok(());
+        }
+
+        let data = serde_json::Value::Object(state);
+        let Ok(_) = utils::request_put(
+            &format!(
+                "http://{}:{}/api/v1/{}/state",
+                self.ip,
+                constants::NL_API_PORT,
+                self.token
+            ),
+            Some(&data),
+        ) else {
+            bail!(utils::generate_connection_error_msg(&self.ip));
+        };
+        Ok(())
+    }
+
+    pub fn ensure_device_ready(&self) -> Result<()> {
+        let info = self.get_device_info()?;
+
+        let is_on = info["state"]["on"]["value"].as_bool().unwrap_or(true);
+        let brightness = info["state"]["brightness"]["value"].as_u64().unwrap_or(100) as u8;
+
+        let mut needs_power = false;
+        let mut needs_brightness = false;
+
+        if !is_on {
+            eprintln!("Device is off. Turning on...");
+            needs_power = true;
+        }
+
+        if brightness == 0 {
+            eprintln!("Device brightness is 0. Setting to 100...");
+            needs_brightness = true;
+        }
+
+        if needs_power || needs_brightness {
+            self.set_state(
+                if needs_power { Some(true) } else { None },
+                if needs_brightness { Some(100) } else { None },
+            )?;
+            // Give the device a moment to respond to the state change
+            std::thread::sleep(std::time::Duration::from_millis(500));
+        }
+
+        Ok(())
+    }
+
+    pub fn get_panels(&self) -> Result<Vec<Panel>> {
+        let res_json = self.get_panel_layout()?;
         let res_panels = res_json["positionData"].as_array().unwrap();
         let mut panels = Vec::new();
         for panel in res_panels.iter() {
@@ -288,49 +390,112 @@ impl NlUdp {
         })
     }
 
-    pub fn sort_panels(
+    pub fn sort_panels_with_orientation(
         &mut self,
         primary_axis: Option<Axis>,
         primary_sort: Option<Sort>,
         secondary_sort: Option<Sort>,
+        global_orientation: u16,
     ) {
         let primary_axis = primary_axis.unwrap_or_default();
         let primary_sort = primary_sort.unwrap_or_default();
         let secondary_sort = secondary_sort.unwrap_or_default();
+
+        // Apply global orientation rotation to coordinates if needed
+        let angle = -(global_orientation as f32).to_radians();
+        let needs_rotation = global_orientation != 0;
+
         let sort_func = match primary_axis {
             Axis::X => match (primary_sort, secondary_sort) {
-                (Sort::Asc, Sort::Asc) => {
-                    |lhs: &Panel, rhs: &Panel| (lhs.x, lhs.y).cmp(&(rhs.x, rhs.y))
-                }
-                (Sort::Asc, Sort::Desc) => {
-                    |lhs: &Panel, rhs: &Panel| (lhs.x, -lhs.y).cmp(&(rhs.x, -rhs.y))
-                }
-                (Sort::Desc, Sort::Asc) => {
-                    |lhs: &Panel, rhs: &Panel| (-lhs.x, lhs.y).cmp(&(-rhs.x, rhs.y))
-                }
-                (Sort::Desc, Sort::Desc) => {
-                    |lhs: &Panel, rhs: &Panel| (-lhs.x, -lhs.y).cmp(&(-rhs.x, -rhs.y))
-                }
+                (Sort::Asc, Sort::Asc) => |lhs: &Panel, rhs: &Panel, angle: f32, rotate: bool| {
+                    if rotate {
+                        let (lx, ly) = Self::rotate_coords(lhs.x, lhs.y, angle);
+                        let (rx, ry) = Self::rotate_coords(rhs.x, rhs.y, angle);
+                        (lx, ly).partial_cmp(&(rx, ry)).unwrap()
+                    } else {
+                        (lhs.x, lhs.y).cmp(&(rhs.x, rhs.y))
+                    }
+                },
+                (Sort::Asc, Sort::Desc) => |lhs: &Panel, rhs: &Panel, angle: f32, rotate: bool| {
+                    if rotate {
+                        let (lx, ly) = Self::rotate_coords(lhs.x, lhs.y, angle);
+                        let (rx, ry) = Self::rotate_coords(rhs.x, rhs.y, angle);
+                        (lx, -ly).partial_cmp(&(rx, -ry)).unwrap()
+                    } else {
+                        (lhs.x, -lhs.y).cmp(&(rhs.x, -rhs.y))
+                    }
+                },
+                (Sort::Desc, Sort::Asc) => |lhs: &Panel, rhs: &Panel, angle: f32, rotate: bool| {
+                    if rotate {
+                        let (lx, ly) = Self::rotate_coords(lhs.x, lhs.y, angle);
+                        let (rx, ry) = Self::rotate_coords(rhs.x, rhs.y, angle);
+                        (-lx, ly).partial_cmp(&(-rx, ry)).unwrap()
+                    } else {
+                        (-lhs.x, lhs.y).cmp(&(-rhs.x, rhs.y))
+                    }
+                },
+                (Sort::Desc, Sort::Desc) => |lhs: &Panel, rhs: &Panel, angle: f32, rotate: bool| {
+                    if rotate {
+                        let (lx, ly) = Self::rotate_coords(lhs.x, lhs.y, angle);
+                        let (rx, ry) = Self::rotate_coords(rhs.x, rhs.y, angle);
+                        (-lx, -ly).partial_cmp(&(-rx, -ry)).unwrap()
+                    } else {
+                        (-lhs.x, -lhs.y).cmp(&(-rhs.x, -rhs.y))
+                    }
+                },
             },
             Axis::Y => match (primary_sort, secondary_sort) {
-                (Sort::Asc, Sort::Asc) => {
-                    |lhs: &Panel, rhs: &Panel| (lhs.y, lhs.x).cmp(&(rhs.y, rhs.x))
-                }
-                (Sort::Asc, Sort::Desc) => {
-                    |lhs: &Panel, rhs: &Panel| (lhs.y, -lhs.x).cmp(&(rhs.y, -rhs.x))
-                }
-                (Sort::Desc, Sort::Asc) => {
-                    |lhs: &Panel, rhs: &Panel| (-lhs.y, lhs.x).cmp(&(-rhs.y, rhs.x))
-                }
-                (Sort::Desc, Sort::Desc) => {
-                    |lhs: &Panel, rhs: &Panel| (-lhs.y, -lhs.x).cmp(&(-rhs.y, -rhs.x))
-                }
+                (Sort::Asc, Sort::Asc) => |lhs: &Panel, rhs: &Panel, angle: f32, rotate: bool| {
+                    if rotate {
+                        let (lx, ly) = Self::rotate_coords(lhs.x, lhs.y, angle);
+                        let (rx, ry) = Self::rotate_coords(rhs.x, rhs.y, angle);
+                        (ly, lx).partial_cmp(&(ry, rx)).unwrap()
+                    } else {
+                        (lhs.y, lhs.x).cmp(&(rhs.y, rhs.x))
+                    }
+                },
+                (Sort::Asc, Sort::Desc) => |lhs: &Panel, rhs: &Panel, angle: f32, rotate: bool| {
+                    if rotate {
+                        let (lx, ly) = Self::rotate_coords(lhs.x, lhs.y, angle);
+                        let (rx, ry) = Self::rotate_coords(rhs.x, rhs.y, angle);
+                        (ly, -lx).partial_cmp(&(ry, -rx)).unwrap()
+                    } else {
+                        (lhs.y, -lhs.x).cmp(&(rhs.y, -rhs.x))
+                    }
+                },
+                (Sort::Desc, Sort::Asc) => |lhs: &Panel, rhs: &Panel, angle: f32, rotate: bool| {
+                    if rotate {
+                        let (lx, ly) = Self::rotate_coords(lhs.x, lhs.y, angle);
+                        let (rx, ry) = Self::rotate_coords(rhs.x, rhs.y, angle);
+                        (-ly, lx).partial_cmp(&(-ry, rx)).unwrap()
+                    } else {
+                        (-lhs.y, lhs.x).cmp(&(-rhs.y, rhs.x))
+                    }
+                },
+                (Sort::Desc, Sort::Desc) => |lhs: &Panel, rhs: &Panel, angle: f32, rotate: bool| {
+                    if rotate {
+                        let (lx, ly) = Self::rotate_coords(lhs.x, lhs.y, angle);
+                        let (rx, ry) = Self::rotate_coords(rhs.x, rhs.y, angle);
+                        (-ly, -lx).partial_cmp(&(-ry, -rx)).unwrap()
+                    } else {
+                        (-lhs.y, -lhs.x).cmp(&(-rhs.y, -rhs.x))
+                    }
+                },
             },
         };
-        self.panels.sort_by(|a: &Panel, b: &Panel| sort_func(a, b));
+        self.panels
+            .sort_by(|a: &Panel, b: &Panel| sort_func(a, b, angle, needs_rotation));
     }
 
-    pub fn update_panels(&self, colors: &[palette::Hwb], trans_time: u16) -> Result<()> {
+    fn rotate_coords(x: i16, y: i16, angle: f32) -> (i32, i32) {
+        let x_f = x as f32;
+        let y_f = y as f32;
+        let rotated_x = (x_f * angle.cos() - y_f * angle.sin()).round() as i32;
+        let rotated_y = (x_f * angle.sin() + y_f * angle.cos()).round() as i32;
+        (rotated_x, rotated_y)
+    }
+
+    pub fn update_panels(&self, colors: &[palette::Hwb], trans_time: i16) -> Result<()> {
         let mut buf = vec![0; 8 * self.panels.len() + 2];
         (buf[0], buf[1]) = utils::split_into_bytes(self.panels.len() as u16);
         for (i, color) in colors.iter().enumerate() {
@@ -348,7 +513,14 @@ impl NlUdp {
                 buf[offset + 4],
                 buf[offset + 5],
             ) = (r, g, b, 0);
-            (buf[offset + 6], buf[offset + 7]) = utils::split_into_bytes(trans_time);
+            // Convert i16 to bytes (supporting -1 for instant transition)
+            // trans_time is in units of 100ms: 1 = 100ms, 2 = 200ms, -1 = instant
+            let trans_time_u16 = if trans_time == -1 {
+                0xFFFF // -1 as u16 (two's complement)
+            } else {
+                trans_time as u16
+            };
+            (buf[offset + 6], buf[offset + 7]) = utils::split_into_bytes(trans_time_u16);
         }
         self.socket.send(&buf)?;
 

--- a/src/now_playing.rs
+++ b/src/now_playing.rs
@@ -145,8 +145,7 @@ mod macos {
             if count == 0 {
                 return None;
             }
-            let artwork: Option<Retained<AnyObject>> =
-                msg_send![&*artworks, objectAtIndex: 0usize];
+            let artwork: Option<Retained<AnyObject>> = msg_send![&*artworks, objectAtIndex: 0usize];
             let artwork = artwork?;
             let raw: Option<Retained<AnyObject>> = msg_send![&*artwork, rawData];
             let raw = raw?;
@@ -265,8 +264,7 @@ mod macos {
 
         let img = image::load_from_memory(image_bytes).ok()?;
         let rgba = img.to_rgba8();
-        let image_data =
-            ImageData::new(rgba.width(), rgba.height(), rgba.as_raw()).ok()?;
+        let image_data = ImageData::new(rgba.width(), rgba.height(), rgba.as_raw()).ok()?;
         let palette: Palette<f64> = Palette::extract(&image_data).ok()?;
         // Sort by population (most prevalent colors first) and take the
         // top 4 that aren't near-black — these are the actual dominant
@@ -282,7 +280,11 @@ mod macos {
                 [rgb.r, rgb.g, rgb.b]
             })
             .collect();
-        if colors.is_empty() { None } else { Some(colors) }
+        if colors.is_empty() {
+            None
+        } else {
+            Some(colors)
+        }
     }
 }
 
@@ -327,8 +329,7 @@ mod linux {
 
         let img = image::load_from_memory(&bytes).ok()?;
         let rgba = img.to_rgba8();
-        let image_data =
-            ImageData::new(rgba.width(), rgba.height(), rgba.as_raw()).ok()?;
+        let image_data = ImageData::new(rgba.width(), rgba.height(), rgba.as_raw()).ok()?;
         let palette: Palette<f64> = Palette::extract(&image_data).ok()?;
         let mut swatches = palette.swatches().to_vec();
         swatches.sort_by(|a, b| b.population().cmp(&a.population()));
@@ -341,6 +342,10 @@ mod linux {
                 [rgb.r, rgb.g, rgb.b]
             })
             .collect();
-        if colors.is_empty() { None } else { Some(colors) }
+        if colors.is_empty() {
+            None
+        } else {
+            Some(colors)
+        }
     }
 }

--- a/src/now_playing.rs
+++ b/src/now_playing.rs
@@ -1,0 +1,346 @@
+/// Album art color extraction for the visualizer.
+///
+/// macOS: Uses ScriptingBridge.framework (via objc2) to query running media
+///   players directly through the ObjC bridge — no subprocess spawning.
+///   - Spotify: title, artist, artwork URL (downloaded via reqwest).
+///   - Apple Music: title, artist, raw artwork bytes from MusicArtwork.rawData.
+///   Falls back to osascript if ScriptingBridge fails.
+///
+/// Linux: Uses `playerctl` subprocess.
+
+/// Returns the title of the currently playing track.
+pub fn get_track_title() -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::get_track_info().map(|info| info.title)
+    }
+    #[cfg(target_os = "linux")]
+    {
+        linux::get_track_title()
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        None
+    }
+}
+
+/// Returns dominant RGB colors extracted from the current track's album artwork.
+pub fn fetch_palette() -> Option<Vec<[u8; 3]>> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::fetch_palette()
+    }
+    #[cfg(target_os = "linux")]
+    {
+        linux::fetch_palette()
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        None
+    }
+}
+
+// ── macOS — ScriptingBridge + osascript fallback ──────────────────────────────
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use objc2::msg_send;
+    use objc2::rc::Retained;
+    use objc2::runtime::{AnyClass, AnyObject};
+    use objc2_foundation::{NSData, NSString};
+
+    #[link(name = "ScriptingBridge", kind = "framework")]
+    unsafe extern "C" {}
+
+    // Four-char code for "playing" state (shared by Spotify and Apple Music).
+    const EPLAYER_PLAYING: u32 = 0x6b505350; // 'kPSP'
+
+    pub struct TrackInfo {
+        pub title: String,
+    }
+
+    pub fn get_track_info() -> Option<TrackInfo> {
+        sb_spotify_title()
+            .or_else(sb_apple_music_title)
+            .or_else(osascript_title)
+            .map(|title| TrackInfo { title })
+    }
+
+    pub fn fetch_palette() -> Option<Vec<[u8; 3]>> {
+        let bytes = sb_spotify_artwork()
+            .or_else(sb_apple_music_artwork)
+            .or_else(osascript_artwork)?;
+        extract_colors(&bytes)
+    }
+
+    // ── ScriptingBridge helpers ───────────────────────────────────────────────
+
+    /// Open a scripting bridge to a running application. Returns None if not running.
+    fn sb_app(bundle_id: &str) -> Option<Retained<AnyObject>> {
+        unsafe {
+            let cls = AnyClass::get(c"SBApplication")?;
+            let bid = NSString::from_str(bundle_id);
+            let app: Option<Retained<AnyObject>> =
+                msg_send![cls, applicationWithBundleIdentifier: &*bid];
+            let app = app?;
+            let running: bool = msg_send![&*app, isRunning];
+            if !running {
+                return None;
+            }
+            let state: u32 = msg_send![&*app, playerState];
+            if state != EPLAYER_PLAYING {
+                return None;
+            }
+            Some(app)
+        }
+    }
+
+    // ── Spotify via ScriptingBridge ───────────────────────────────────────────
+
+    fn sb_spotify_title() -> Option<String> {
+        let app = sb_app("com.spotify.client")?;
+        unsafe {
+            let track: Option<Retained<AnyObject>> = msg_send![&*app, currentTrack];
+            let track = track?;
+            let name: Option<Retained<NSString>> = msg_send![&*track, name];
+            name.map(|s| s.to_string())
+        }
+    }
+
+    fn sb_spotify_artwork() -> Option<Vec<u8>> {
+        let app = sb_app("com.spotify.client")?;
+        unsafe {
+            let track: Option<Retained<AnyObject>> = msg_send![&*app, currentTrack];
+            let track = track?;
+            let url: Option<Retained<NSString>> = msg_send![&*track, artworkUrl];
+            let url = url?;
+            reqwest::blocking::get(&*url.to_string())
+                .ok()?
+                .bytes()
+                .ok()
+                .map(|b| b.to_vec())
+        }
+    }
+
+    // ── Apple Music via ScriptingBridge ───────────────────────────────────────
+
+    fn sb_apple_music_title() -> Option<String> {
+        let app = sb_app("com.apple.Music")?;
+        unsafe {
+            let track: Option<Retained<AnyObject>> = msg_send![&*app, currentTrack];
+            let track = track?;
+            let name: Option<Retained<NSString>> = msg_send![&*track, name];
+            name.map(|s| s.to_string())
+        }
+    }
+
+    fn sb_apple_music_artwork() -> Option<Vec<u8>> {
+        let app = sb_app("com.apple.Music")?;
+        unsafe {
+            let track: Option<Retained<AnyObject>> = msg_send![&*app, currentTrack];
+            let track = track?;
+            let artworks: Option<Retained<AnyObject>> = msg_send![&*track, artworks];
+            let artworks = artworks?;
+            let count: usize = msg_send![&*artworks, count];
+            if count == 0 {
+                return None;
+            }
+            let artwork: Option<Retained<AnyObject>> =
+                msg_send![&*artworks, objectAtIndex: 0usize];
+            let artwork = artwork?;
+            let raw: Option<Retained<AnyObject>> = msg_send![&*artwork, rawData];
+            let raw = raw?;
+            // rawData returns NSData with JPEG/PNG image bytes.
+            raw.downcast_ref::<NSData>().map(|d| d.to_vec())
+        }
+    }
+
+    // ── osascript fallback ───────────────────────────────────────────────────
+
+    fn osascript_title() -> Option<String> {
+        for script in [
+            r#"tell application "System Events"
+                if not (exists process "Spotify") then return "NOT_RUNNING"
+            end tell
+            tell application "Spotify"
+                if player state is not playing then return "NOT_PLAYING"
+                return name of current track
+            end tell"#,
+            r#"tell application "System Events"
+                if not (exists process "Music") then return "NOT_RUNNING"
+            end tell
+            tell application "Music"
+                if player state is not playing then return "NOT_PLAYING"
+                return name of current track
+            end tell"#,
+        ] {
+            if let Some(title) = run_osascript(script) {
+                return Some(title);
+            }
+        }
+        None
+    }
+
+    fn osascript_artwork() -> Option<Vec<u8>> {
+        // Spotify: artwork URL.
+        let script = r#"tell application "System Events"
+            if not (exists process "Spotify") then return "NOT_RUNNING"
+        end tell
+        tell application "Spotify"
+            if player state is not playing then return "NOT_PLAYING"
+            return artwork url of current track
+        end tell"#;
+        if let Some(url) = run_osascript(script) {
+            if let Some(bytes) = reqwest::blocking::get(&url)
+                .ok()
+                .and_then(|r| r.bytes().ok())
+                .map(|b| b.to_vec())
+            {
+                return Some(bytes);
+            }
+        }
+        // Apple Music: use iTunes Search API.
+        let script = r#"tell application "System Events"
+            if not (exists process "Music") then return "NOT_RUNNING"
+        end tell
+        tell application "Music"
+            if player state is not playing then return "NOT_PLAYING"
+            return (name of current track) & " " & (artist of current track)
+        end tell"#;
+        if let Some(query) = run_osascript(script) {
+            if let Some(url) = itunes_artwork_url(&query) {
+                return reqwest::blocking::get(&url)
+                    .ok()
+                    .and_then(|r| r.bytes().ok())
+                    .map(|b| b.to_vec());
+            }
+        }
+        None
+    }
+
+    fn run_osascript(script: &str) -> Option<String> {
+        let output = std::process::Command::new("osascript")
+            .args(["-e", script])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if text.is_empty() || text == "NOT_RUNNING" || text == "NOT_PLAYING" {
+            return None;
+        }
+        Some(text)
+    }
+
+    fn itunes_artwork_url(query: &str) -> Option<String> {
+        let url = format!(
+            "https://itunes.apple.com/search?term={}&media=music&limit=1",
+            urlencoded(query)
+        );
+        let resp: serde_json::Value = reqwest::blocking::get(&url).ok()?.json().ok()?;
+        let art = resp["results"][0]["artworkUrl100"].as_str()?;
+        Some(art.replace("100x100", "600x600"))
+    }
+
+    fn urlencoded(s: &str) -> String {
+        let mut out = String::with_capacity(s.len() * 2);
+        for b in s.bytes() {
+            match b {
+                b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' => {
+                    out.push(b as char);
+                }
+                b' ' => out.push('+'),
+                _ => {
+                    out.push('%');
+                    out.push_str(&format!("{:02X}", b));
+                }
+            }
+        }
+        out
+    }
+
+    fn extract_colors(image_bytes: &[u8]) -> Option<Vec<[u8; 3]>> {
+        use auto_palette::{ImageData, Palette};
+
+        let img = image::load_from_memory(image_bytes).ok()?;
+        let rgba = img.to_rgba8();
+        let image_data =
+            ImageData::new(rgba.width(), rgba.height(), rgba.as_raw()).ok()?;
+        let palette: Palette<f64> = Palette::extract(&image_data).ok()?;
+        // Sort by population (most prevalent colors first) and take the
+        // top 4 that aren't near-black — these are the actual dominant
+        // colors of the album art, not theme-scored "interesting" picks.
+        let mut swatches = palette.swatches().to_vec();
+        swatches.sort_by(|a, b| b.population().cmp(&a.population()));
+        let colors: Vec<[u8; 3]> = swatches
+            .iter()
+            .filter(|s| s.color().to_oklch().l > 0.15)
+            .take(4)
+            .map(|s| {
+                let rgb = s.color().to_rgb();
+                [rgb.r, rgb.g, rgb.b]
+            })
+            .collect();
+        if colors.is_empty() { None } else { Some(colors) }
+    }
+}
+
+// ── Linux ─────────────────────────────────────────────────────────────────────
+
+#[cfg(target_os = "linux")]
+mod linux {
+    pub fn get_track_title() -> Option<String> {
+        let output = std::process::Command::new("playerctl")
+            .args(["metadata", "title"])
+            .output()
+            .ok()?;
+        if output.status.success() {
+            let title = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !title.is_empty() {
+                return Some(title);
+            }
+        }
+        None
+    }
+
+    pub fn fetch_palette() -> Option<Vec<[u8; 3]>> {
+        let output = std::process::Command::new("playerctl")
+            .args(["metadata", "mpris:artUrl"])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let url = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if url.is_empty() {
+            return None;
+        }
+
+        let bytes: Vec<u8> = if url.starts_with("file://") {
+            std::fs::read(url.trim_start_matches("file://")).ok()?
+        } else {
+            reqwest::blocking::get(&url).ok()?.bytes().ok()?.to_vec()
+        };
+
+        use auto_palette::{ImageData, Palette};
+
+        let img = image::load_from_memory(&bytes).ok()?;
+        let rgba = img.to_rgba8();
+        let image_data =
+            ImageData::new(rgba.width(), rgba.height(), rgba.as_raw()).ok()?;
+        let palette: Palette<f64> = Palette::extract(&image_data).ok()?;
+        let mut swatches = palette.swatches().to_vec();
+        swatches.sort_by(|a, b| b.population().cmp(&a.population()));
+        let colors: Vec<[u8; 3]> = swatches
+            .iter()
+            .filter(|s| s.color().to_oklch().l > 0.15)
+            .take(4)
+            .map(|s| {
+                let rgb = s.color().to_rgb();
+                [rgb.r, rgb.g, rgb.b]
+            })
+            .collect();
+        if colors.is_empty() { None } else { Some(colors) }
+    }
+}

--- a/src/palettes.rs
+++ b/src/palettes.rs
@@ -1,11 +1,13 @@
 /// Predefined color palettes
 ///
 /// This module contains named color palettes that users can reference
-/// in their config.toml instead of manually specifying hue arrays.
+/// in their config.toml instead of manually specifying RGB color arrays.
+/// Each color is an [R, G, B] triplet. At runtime these are converted
+/// to Oklch so the visualizer can animate perceptually-uniform lightness.
 use std::collections::HashMap;
 
 /// Get a predefined palette by name
-pub fn get_palette(name: &str) -> Option<Vec<u16>> {
+pub fn get_palette(name: &str) -> Option<Vec<[u8; 3]>> {
     let palettes = get_all_palettes();
     palettes.get(name).cloned()
 }
@@ -16,51 +18,165 @@ pub fn get_palette_names() -> Vec<String> {
 }
 
 /// Get all predefined palettes
-fn get_all_palettes() -> HashMap<String, Vec<u16>> {
+fn get_all_palettes() -> HashMap<String, Vec<[u8; 3]>> {
     let mut palettes = HashMap::new();
 
+    // Deep sky blues, indigos, magentas, and cyans
     palettes.insert(
         "ocean-nightclub".to_string(),
-        vec![195, 210, 240, 270, 285, 300, 180],
+        vec![
+            [0, 191, 255], // deep sky blue
+            [0, 128, 255], // azure
+            [0, 0, 255],   // blue
+            [128, 0, 255], // violet
+            [191, 0, 255], // purple
+            [255, 0, 255], // magenta
+            [0, 255, 255], // cyan
+        ],
     );
 
+    // Warm reds, oranges, deep pinks, and purples
     palettes.insert(
         "sunset".to_string(),
-        vec![15, 25, 340, 350, 0, 10, 310, 280],
+        vec![
+            [255, 64, 0],  // red-orange
+            [255, 106, 0], // orange
+            [255, 0, 85],  // crimson
+            [255, 0, 43],  // rose
+            [255, 0, 0],   // red
+            [255, 43, 0],  // scarlet
+            [255, 0, 128], // hot pink
+            [170, 0, 255], // violet
+        ],
     );
 
+    // Magentas, purples, indigos, and cyans
     palettes.insert(
         "house-music-party".to_string(),
-        vec![300, 285, 270, 255, 240, 195, 180],
+        vec![
+            [255, 0, 255], // magenta
+            [191, 0, 255], // purple
+            [128, 0, 255], // violet
+            [64, 0, 255],  // indigo
+            [0, 0, 255],   // blue
+            [0, 191, 255], // deep sky blue
+            [0, 255, 255], // cyan
+        ],
     );
 
+    // Cyans, teals, greens, and limes
     palettes.insert(
         "tropical-beach".to_string(),
-        vec![180, 175, 170, 160, 90, 75, 60],
+        vec![
+            [0, 255, 255], // cyan
+            [0, 255, 234], // turquoise
+            [0, 255, 213], // aquamarine
+            [0, 255, 170], // spring green
+            [128, 255, 0], // lime
+            [191, 255, 0], // chartreuse
+            [255, 255, 0], // yellow
+        ],
     );
 
-    palettes.insert("fire".to_string(), vec![0, 10, 20, 30, 40, 50, 60]);
+    // Reds through oranges to yellow
+    palettes.insert(
+        "fire".to_string(),
+        vec![
+            [255, 0, 0],   // red
+            [255, 43, 0],  // scarlet
+            [255, 85, 0],  // vermillion
+            [255, 128, 0], // orange
+            [255, 170, 0], // amber
+            [255, 213, 0], // golden
+            [255, 255, 0], // yellow
+        ],
+    );
 
-    palettes.insert("forest".to_string(), vec![90, 100, 110, 120, 130, 140, 150]);
+    // Chartreuse through greens to teal
+    palettes.insert(
+        "forest".to_string(),
+        vec![
+            [128, 255, 0], // lime
+            [85, 255, 0],  // green-yellow
+            [43, 255, 0],  // lawn green
+            [0, 255, 0],   // green
+            [0, 255, 43],  // emerald
+            [0, 255, 85],  // jade
+            [0, 255, 128], // mint
+        ],
+    );
 
-    palettes.insert("neon-rainbow".to_string(), vec![0, 60, 120, 180, 240, 300]);
+    // Full spectrum rainbow
+    palettes.insert(
+        "neon-rainbow".to_string(),
+        vec![
+            [255, 0, 0],   // red
+            [255, 255, 0], // yellow
+            [0, 255, 0],   // green
+            [0, 255, 255], // cyan
+            [0, 0, 255],   // blue
+            [255, 0, 255], // magenta
+        ],
+    );
 
+    // Pinks from deep to light rose
     palettes.insert(
         "pink-dreams".to_string(),
-        vec![320, 325, 330, 335, 340, 345, 350],
+        vec![
+            [255, 0, 170], // deep pink
+            [255, 0, 149], // hot pink
+            [255, 0, 128], // pink
+            [255, 0, 106], // rose
+            [255, 0, 85],  // fuchsia-rose
+            [255, 0, 64],  // crimson-rose
+            [255, 0, 43],  // warm rose
+        ],
     );
 
+    // Cool blue spectrum
     palettes.insert(
         "cool-blues".to_string(),
-        vec![190, 200, 210, 220, 230, 240, 250],
+        vec![
+            [0, 170, 255], // sky blue
+            [0, 128, 255], // azure
+            [0, 85, 255],  // royal blue
+            [0, 43, 255],  // cobalt
+            [0, 0, 255],   // blue
+            [43, 0, 255],  // indigo
+            [64, 0, 255],  // deep indigo
+        ],
     );
 
+    // Teenage Mutant Ninja Turtles: character bandana colors + turtle green
     palettes.insert(
         "tmnt".to_string(),
-        vec![125, 130, 240, 245, 25, 30, 0, 5, 280, 285],
+        vec![
+            [0, 200, 0],   // turtle green
+            [0, 80, 255],  // Leonardo blue
+            [128, 0, 255], // Donatello purple
+            [255, 128, 0], // Michelangelo orange
+            [255, 0, 0],   // Raphael red
+            [0, 255, 64],  // sewer green
+            [0, 128, 255], // Leonardo azure
+            [170, 0, 255], // Donatello violet
+            [255, 170, 0], // Michelangelo amber
+            [255, 43, 0],  // Raphael scarlet
+        ],
     );
 
-    palettes.insert("christmas".to_string(), vec![360, 0, 120, 5, 125, 5, 360]);
+    // Red, white, and green
+    palettes.insert(
+        "christmas".to_string(),
+        vec![
+            [255, 0, 0],     // red
+            [255, 0, 0],     // red
+            [0, 255, 0],     // green
+            [255, 21, 0],    // warm red
+            [0, 255, 43],    // festive green
+            [255, 21, 0],    // warm red
+            [255, 255, 255], // white
+        ],
+    );
 
     palettes
 }

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -2,7 +2,7 @@ use crate::constants;
 use ratatui::crossterm::{execute, terminal};
 use std::{
     backtrace, fs,
-    io::{stdout, Write},
+    io::{Write, stdout},
 };
 
 /// Registers a custom panic hook to handle application crashes gracefully.

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -5,6 +5,11 @@ use std::{
     io::{stdout, Write},
 };
 
+/// Registers a custom panic hook to handle application crashes gracefully.
+///
+/// Disables raw mode and leaves alternate screen before printing crash message.
+/// Captures and saves backtrace to cache/audioleaf_backtrace.log if possible.
+/// Ensures TUI state is restored on panic in threads like event handler.
 pub fn register_backtrace_panic_handler() {
     std::panic::set_hook(Box::new(|panic_info| {
         let _ = terminal::disable_raw_mode();

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -2,6 +2,14 @@ use crate::utils;
 use num_complex::Complex32;
 use palette::Hwb;
 
+/// Recursive in-place radix-2 Cooley-Tukey FFT implementation.
+///
+/// Computes the discrete Fourier transform for a signal of length `n`.
+/// Modifies input `x` and stores result in `y`.
+/// `step` determines the stride between samples in sub-transforms for decimation-in-time approach.
+///
+/// Base case: n=1 copies x[0] to y[0].
+/// Recursive: splits into even/odd indices, computes twiddle factors for butterfly combination.
 fn fft(x: &mut [Complex32], y: &mut [Complex32], n: usize, step: usize) {
     if n == 1 {
         y[0] = x[0];
@@ -18,6 +26,19 @@ fn fft(x: &mut [Complex32], y: &mut [Complex32], n: usize, step: usize) {
     }
 }
 
+/// Processes raw time-domain audio samples to produce frequency-domain spectrum amplitudes for visualization.
+///
+/// Performs FFT on padded input (to next power of two), extracts positive frequencies,
+/// normalizes by sqrt(n), applies gain, and clamps amplitudes to [0,1] using x / sqrt(1 + x^2) sigmoid-like function.
+///
+/// # Arguments
+///
+/// * `samples` - Vec of f32 mono audio samples.
+/// * `gain` - Amplification factor applied before clamping.
+///
+/// # Returns
+///
+/// Vec<f32> of amplitude values for each frequency bin (up to Nyquist).
 pub fn process(samples: Vec<f32>, gain: f32) -> Vec<f32> {
     let mut n = samples.len();
     let mut complex_samples = samples
@@ -44,6 +65,24 @@ pub fn process(samples: Vec<f32>, gain: f32) -> Vec<f32> {
         .collect::<Vec<_>>()
 }
 
+/// Updates the blackness component of HWB colors based on audio frequency spectrum for animated visualization.
+///
+/// Divides the frequency range [min_freq, max_freq] into `colors.len()` logarithmic intervals.
+/// For each interval, tracks maximum amplitude (with equal loudness correction) and updates blackness
+/// with velocity-based decay/increase for smooth transitions. Uses cubic easing functions for rates.
+///
+/// # Arguments
+///
+/// * `spectrum` - FFT-derived amplitudes for frequency bins.
+/// * `hz_per_bin` - Frequency resolution (Hz per bin in spectrum).
+/// * `min_freq`/`max_freq` - Frequency range to consider for color mapping.
+/// * `colors` - Mutable slice of HWB colors; updates their blackness [0,1] (1=white, 0=saturated).
+/// * `prev_max` - Previous max amplitudes per interval for delta computation (mutated).
+/// * `speed` - Velocity accumulators for blackness changes per interval (mutated).
+///
+/// # Panics
+///
+/// May panic if spectrum length insufficient or invalid frequency params.
 pub fn update_colors(
     spectrum: Vec<f32>,
     hz_per_bin: u32,

--- a/src/processing.rs
+++ b/src/processing.rs
@@ -1,6 +1,5 @@
 use crate::utils;
 use num_complex::Complex32;
-use palette::Hwb;
 
 /// Recursive in-place radix-2 Cooley-Tukey FFT implementation.
 ///
@@ -65,34 +64,37 @@ pub fn process(samples: Vec<f32>, gain: f32) -> Vec<f32> {
         .collect::<Vec<_>>()
 }
 
-/// Updates the blackness component of HWB colors based on audio frequency spectrum for animated visualization.
+/// Updates per-panel brightness values based on audio frequency spectrum for animated visualization.
 ///
-/// Divides the frequency range [min_freq, max_freq] into `colors.len()` logarithmic intervals.
-/// For each interval, tracks maximum amplitude (with equal loudness correction) and updates blackness
+/// Divides the frequency range [min_freq, max_freq] into `brightness.len()` logarithmic intervals.
+/// For each interval, tracks maximum amplitude (with equal loudness correction) and updates brightness
 /// with velocity-based decay/increase for smooth transitions. Uses cubic easing functions for rates.
+///
+/// Brightness is a multiplier in [0,1] applied to the base Oklch color's lightness.
+/// At 0 the panel is black; at 1 it shows the exact target color the user specified.
 ///
 /// # Arguments
 ///
 /// * `spectrum` - FFT-derived amplitudes for frequency bins.
 /// * `hz_per_bin` - Frequency resolution (Hz per bin in spectrum).
 /// * `min_freq`/`max_freq` - Frequency range to consider for color mapping.
-/// * `colors` - Mutable slice of HWB colors; updates their blackness [0,1] (1=white, 0=saturated).
+/// * `brightness` - Mutable slice of brightness multipliers [0,1] per panel (mutated).
 /// * `prev_max` - Previous max amplitudes per interval for delta computation (mutated).
-/// * `speed` - Velocity accumulators for blackness changes per interval (mutated).
+/// * `speed` - Velocity accumulators for brightness changes per interval (mutated).
 ///
 /// # Panics
 ///
 /// May panic if spectrum length insufficient or invalid frequency params.
-pub fn update_colors(
+pub fn update_brightness(
     spectrum: Vec<f32>,
     hz_per_bin: u32,
     min_freq: u16,
     max_freq: u16,
-    colors: &mut [Hwb],
+    brightness: &mut [f32],
     prev_max: &mut [f32],
     speed: &mut [f32],
 ) {
-    let n_panels = colors.len();
+    let n_panels = brightness.len();
     let (min_freq, max_freq) = (min_freq as f32, max_freq as f32);
     let multiplier = (max_freq / min_freq).powf(1.0 / n_panels as f32);
     let (mut intervals, mut cutoff) = (Vec::new(), min_freq);
@@ -108,13 +110,24 @@ pub fn update_colors(
         let cur_freq = (i as u32) * hz_per_bin + hz_per_bin / 2;
         if cur_freq > intervals[cur_interval] || i == n_bins - 1 {
             let ampl_delta = cur_max - prev_max[cur_interval];
-            if ampl_delta.is_sign_positive() {
-                speed[cur_interval] = -rate_func_inc(ampl_delta);
+            if ampl_delta > 0.0 {
+                // Audio getting louder → increase brightness
+                speed[cur_interval] = rate_func_inc(ampl_delta);
+            } else if cur_max > 0.01 {
+                // Audio getting quieter but still present → normal decay
+                speed[cur_interval] = -(rate_func_dec(-ampl_delta).max(0.01));
             } else {
-                speed[cur_interval] = rate_func_dec(-ampl_delta).max(1e-4);
+                // Audio is essentially silent → strong decay so panels actually go dark
+                // Without this, the tiny 1e-4 floor makes panels take minutes to fade out
+                speed[cur_interval] = -(0.15_f32.max(brightness[cur_interval] * 0.3));
             }
-            colors[cur_interval].blackness =
-                (colors[cur_interval].blackness + speed[cur_interval]).clamp(0.0, 1.0);
+            brightness[cur_interval] =
+                (brightness[cur_interval] + speed[cur_interval]).clamp(0.0, 1.0);
+
+            // Floor very small values to true zero so panels go fully dark
+            if brightness[cur_interval] < 0.005 {
+                brightness[cur_interval] = 0.0;
+            }
 
             prev_max[cur_interval] = cur_max;
             cur_max = 0.0;
@@ -125,4 +138,165 @@ pub fn update_colors(
         }
         cur_max = cur_max.max(utils::equalize(ampl, cur_freq).min(1.0));
     }
+}
+
+/// Updates per-panel brightness using an energy wave / cascade animation.
+///
+/// Instead of each panel independently tracking a frequency band (like `update_brightness`),
+/// this effect creates a traveling wave of light across the panels:
+///
+/// 1. Compute overall audio energy from the full spectrum (max equalized amplitude).
+/// 2. Cascade: shift each panel's brightness to the next panel (with per-step decay).
+/// 3. Feed new energy into the first panel with smooth attack/decay.
+///
+/// The result is a flowing ripple of light that propagates across panels,
+/// with intensity driven by audio amplitude. Visually very different from the
+/// per-band spectrum effect.
+///
+/// # Arguments
+///
+/// * `spectrum` - FFT-derived amplitudes for frequency bins.
+/// * `hz_per_bin` - Frequency resolution (Hz per bin in spectrum).
+/// * `min_freq`/`max_freq` - Frequency range to consider.
+/// * `brightness` - Mutable slice of brightness multipliers [0,1] per panel (mutated).
+/// * `prev_max` - Previous overall energy for delta computation (only index 0 used).
+/// * `speed` - Velocity accumulator for the lead panel's brightness (only index 0 used).
+pub fn update_brightness_wave(
+    spectrum: Vec<f32>,
+    hz_per_bin: u32,
+    min_freq: u16,
+    max_freq: u16,
+    brightness: &mut [f32],
+    prev_max: &mut [f32],
+    speed: &mut [f32],
+) {
+    let n_panels = brightness.len();
+    if n_panels == 0 {
+        return;
+    }
+    let (min_freq, max_freq) = (min_freq as u32, max_freq as u32);
+
+    // 1. Compute overall audio energy: max equalized amplitude in the frequency range
+    let mut overall_energy = 0.0_f32;
+    for (i, &ampl) in spectrum.iter().enumerate() {
+        let cur_freq = (i as u32) * hz_per_bin + hz_per_bin / 2;
+        if cur_freq < min_freq {
+            continue;
+        }
+        if cur_freq > max_freq {
+            break;
+        }
+        overall_energy = overall_energy.max(utils::equalize(ampl, cur_freq).min(1.0));
+    }
+
+    // 2. Cascade: shift brightness values from left to right with per-step decay
+    // This creates the traveling wave — each panel inherits its left neighbor's value
+    let cascade_decay = 0.92;
+    for i in (1..n_panels).rev() {
+        brightness[i] = brightness[i - 1] * cascade_decay;
+    }
+
+    // 3. Feed new energy into the lead panel (index 0) with smooth attack/decay
+    let rate_func_inc = |x: f32| -> f32 { 1.0 - (1.0 - x).powi(3) };
+    let rate_func_dec = |x: f32| -> f32 { 0.9 * (1.0 - (1.0 - x).powi(4)) };
+
+    let energy_delta = overall_energy - prev_max[0];
+    if energy_delta > 0.0 {
+        speed[0] = rate_func_inc(energy_delta);
+    } else if overall_energy > 0.01 {
+        // Audio getting quieter but still present → normal decay
+        speed[0] = -(rate_func_dec(-energy_delta).max(0.01));
+    } else {
+        // Audio is essentially silent → strong decay so panels actually go dark
+        speed[0] = -(0.15_f32.max(brightness[0] * 0.3));
+    }
+    brightness[0] = (brightness[0] + speed[0]).clamp(0.0, 1.0);
+    prev_max[0] = overall_energy;
+
+    // Floor very small values to true zero so panels go fully dark
+    for b in brightness.iter_mut() {
+        if *b < 0.005 {
+            *b = 0.0;
+        }
+    }
+}
+
+/// Updates all panels with a unified beat-reactive pulse animation.
+///
+/// All panels flash together on audio transients (beats, hits, kicks) and
+/// fade quickly between them. The music's own rhythm drives the animation —
+/// no fixed-rate oscillation.
+///
+/// Uses asymmetric attack/decay with signal boost:
+/// - **Boost**: `sqrt(energy)` expands the dynamic range so moderate audio
+///   levels (0.25 → 0.5, 0.5 → 0.71) still produce visible flashes.
+/// - **Attack**: When boosted energy exceeds current brightness, snap to it
+///   almost instantly (90% of the gap per frame). Every kick/snare/transient
+///   produces an immediate flash.
+/// - **Decay**: When energy drops, brightness decays exponentially (×0.72
+///   per frame ≈ 250ms to half-brightness at 5.3 fps). The fast falloff
+///   creates strong contrast between beats — panels go noticeably dark
+///   before the next hit lands.
+///
+/// State layout:
+/// - `prev_max[0]`: current display brightness level (smoothed)
+///
+/// # Arguments
+///
+/// * `spectrum` - FFT-derived amplitudes for frequency bins.
+/// * `hz_per_bin` - Frequency resolution (Hz per bin in spectrum).
+/// * `min_freq`/`max_freq` - Frequency range to consider.
+/// * `brightness` - Mutable slice of brightness multipliers [0,1] per panel (all set to same value).
+/// * `prev_max` - Index 0 stores the current pulse brightness across frames.
+/// * `speed` - Unused by this effect (reserved for compatibility).
+pub fn update_brightness_pulse(
+    spectrum: Vec<f32>,
+    hz_per_bin: u32,
+    min_freq: u16,
+    max_freq: u16,
+    brightness: &mut [f32],
+    prev_max: &mut [f32],
+    _speed: &mut [f32],
+) {
+    if brightness.is_empty() {
+        return;
+    }
+    let (min_freq, max_freq) = (min_freq as u32, max_freq as u32);
+
+    // 1. Compute overall audio energy: max equalized amplitude in the frequency range
+    let mut overall_energy = 0.0_f32;
+    for (i, &ampl) in spectrum.iter().enumerate() {
+        let cur_freq = (i as u32) * hz_per_bin + hz_per_bin / 2;
+        if cur_freq < min_freq {
+            continue;
+        }
+        if cur_freq > max_freq {
+            break;
+        }
+        overall_energy = overall_energy.max(utils::equalize(ampl, cur_freq).min(1.0));
+    }
+
+    // 2. Boost signal: sqrt expands the dynamic range so moderate levels produce visible pulses
+    //    Without this, typical music energy (0.2-0.5) barely lights the panels
+    let boosted = overall_energy.sqrt();
+
+    // 3. Asymmetric attack/decay for punchy beat-reactive pulse
+    if boosted > prev_max[0] {
+        // Near-instant attack: snap 90% of the gap per frame
+        // Every transient produces an immediate flash
+        prev_max[0] += 0.9 * (boosted - prev_max[0]);
+    } else {
+        // Fast exponential decay between beats
+        // 0.72 per frame at ~5.3 fps ≈ 250ms to half-brightness
+        // Creates strong contrast so the next beat has real impact
+        prev_max[0] *= 0.72;
+    }
+
+    // Floor very small values to true zero so panels go fully dark
+    if prev_max[0] < 0.005 {
+        prev_max[0] = 0.0;
+    }
+
+    // 4. All panels pulse together at the same brightness
+    brightness.fill(prev_max[0]);
 }

--- a/src/ssdp.rs
+++ b/src/ssdp.rs
@@ -8,6 +8,9 @@ use std::{
 const SSDP_MULTICAST_ADDR: &str = "239.255.255.250";
 const SSDP_MULTICAST_PORT: &str = "1900";
 
+/// Parses an SSDP response string to extract the device name and IP address.
+///
+/// Returns `Some((name, ip))` if both are found in the headers, `None` otherwise.
 fn parse_name_and_ip(s: &str) -> Option<(String, String)> {
     let headers = s.split("\r\n");
     let (mut name, mut ip) = (None, None);
@@ -37,6 +40,21 @@ fn parse_name_and_ip(s: &str) -> Option<(String, String)> {
     }
 }
 
+/// Discovers Nanoleaf devices on the local network using the SSDP M-SEARCH protocol.
+///
+/// Sends multicast search requests for known Nanoleaf device types including Canvas (nl29),
+/// Shapes (nl42), Elements (nl52), and Aurora Light Panels.
+///
+/// Listens for responses for a timeout of 10 seconds, avoiding duplicate devices based on IP address.
+///
+/// # Returns
+///
+/// A tuple `(Vec<String>, Vec<Ipv4Addr>)` containing the discovered device names and their corresponding IP addresses.
+///
+/// # Errors
+///
+/// Returns an `anyhow::Error` if socket binding, multicast joining, sending requests,
+/// receiving responses, or IP parsing fails.
 pub fn ssdp_msearch() -> Result<(Vec<String>, Vec<Ipv4Addr>)> {
     let socket = UdpSocket::bind("0.0.0.0:0")?;
     socket.join_multicast_v4(&SSDP_MULTICAST_ADDR.parse()?, &"0.0.0.0".parse()?)?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,20 +1,20 @@
-use anyhow::{bail, Result};
-use palette::rgb::Srgb;
+use anyhow::{Result, bail};
+use palette::{IntoColor, Oklch, Srgb};
 use ratatui::{
-    backend::{Backend, CrosstermBackend},
+    Terminal,
+    backend::CrosstermBackend,
     crossterm::{
         event::{self, Event},
         execute,
-        terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+        terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
     },
     style::{Color, Stylize},
     text::Line,
-    Terminal,
 };
 use reqwest::blocking::Client;
 use std::{
     fmt::Display,
-    io::{self, stdout, Write},
+    io::{self, Stdout, Write, stdout},
     net::Ipv4Addr,
 };
 
@@ -45,7 +45,9 @@ pub fn choose_ip(v: &[impl Display]) -> Result<Choice> {
     }
     let n = v.len();
     loop {
-        print!("Choose an option (by entering its number), enter 'M' to provide the IP adress manually or enter 'Q' to quit: ");
+        print!(
+            "Choose an option (by entering its number), enter 'M' to provide the IP adress manually or enter 'Q' to quit: "
+        );
         io::stdout().flush()?;
         let mut input = String::new();
         match io::stdin().read_line(&mut input) {
@@ -125,8 +127,8 @@ pub fn wait_for_any_key() -> Result<()> {
 ///
 /// # Returns
 ///
-/// `Result<Terminal<CrosstermBackend<Stdout>>>` wrapped in impl Backend.
-pub fn init_tui() -> Result<Terminal<impl Backend>> {
+/// `Result<Terminal<CrosstermBackend<Stdout>>>`.
+pub fn init_tui() -> Result<Terminal<CrosstermBackend<Stdout>>> {
     enable_raw_mode()?;
     execute!(stdout(), EnterAlternateScreen)?;
     Terminal::new(CrosstermBackend::new(stdout())).map_err(anyhow::Error::from)
@@ -226,23 +228,24 @@ pub fn request_get(url: &str) -> Result<String> {
     Ok(res.text()?.to_string())
 }
 
-/// Generates HWB colors from a list of hues, expanding or truncating to exact count `n`.
+/// Generates Oklch base colors from a list of RGB values, expanding or truncating to exact count `n`.
 ///
-/// Repeats last hue if fewer than `n`, cycles if more? No, resizes vec from hues slice.
-/// Hue=360 special-cased as white (H=0.1, W=1.0, B=0.0); others H=hue f32, W=0, B=1 (saturated full brightness).
+/// Repeats last color if fewer than `n`.
+/// Each RGB triplet is converted to Oklch preserving the perceptually correct hue, chroma, and lightness.
+/// The returned colors represent the **target** appearance at full brightness — the visualizer
+/// animates a separate brightness multiplier [0,1] that scales lightness, ensuring the original
+/// RGB color is faithfully reproduced at peak audio amplitude.
 ///
-/// Used to map palette hues to panel colors in visualizer.
-pub fn colors_from_hues(hues: &[u16], n: usize) -> Vec<palette::Hwb> {
-    let mut res = Vec::from(hues);
-    res.resize(n, *hues.last().unwrap());
-    res.into_iter()
-        .map(|hue| {
-            // Use special hue value 360 to represent white (high whiteness)
-            if hue == 360 {
-                palette::Hwb::new(0.1, 1.0, 0.0) // White: any hue, high whiteness, starts black
-            } else {
-                palette::Hwb::new(hue as f32, 0.0, 1.0) // Normal colors: no whiteness
-            }
+/// Used to map palette colors to panel base colors in visualizer.
+pub fn colors_from_rgb(rgb_colors: &[[u8; 3]], n: usize) -> Vec<Oklch> {
+    // Spread colors evenly across n panels.  With 4 colors and 12 panels
+    // each color covers 3 panels instead of the last color filling 9.
+    (0..n)
+        .map(|i| {
+            let color_idx = i * rgb_colors.len() / n;
+            let [r, g, b] = rgb_colors[color_idx];
+            let srgb = Srgb::new(r, g, b).into_format::<f32>();
+            srgb.into_color()
         })
         .collect()
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -24,6 +24,21 @@ pub enum Choice {
     Quit,
 }
 
+/// Prompts the user to select an option from a numbered list interactively.
+///
+/// Displays the list with indices starting from 1.
+/// Accepts input: number (selects index-1), "M" for manual mode, "Q" to quit.
+/// Loops until valid input, flushes stdout for immediate prompt visibility.
+///
+/// Used for selecting discovered Nanoleaf devices by name.
+///
+/// # Arguments
+///
+/// * `v` - Slice of displayable items (e.g., device names).
+///
+/// # Returns
+///
+/// `Result<Choice>` - Automatic selection with index, Manual, or Quit variant.
 pub fn choose_ip(v: &[impl Display]) -> Result<Choice> {
     for (i, option) in v.iter().enumerate() {
         println!("{}. {}", i + 1, option);
@@ -52,6 +67,14 @@ pub fn choose_ip(v: &[impl Display]) -> Result<Choice> {
     }
 }
 
+/// Interactively prompts for manual IPv4 address input from stdin.
+///
+/// Loops reading lines until valid IPv4 or "Q" to quit.
+/// Used after SSDP discovery if user chooses manual entry.
+///
+/// # Returns
+///
+/// `Result<Option<Ipv4Addr>>` - Parsed IP or None on quit/cancel.
 pub fn get_ip_from_stdin() -> Result<Option<Ipv4Addr>> {
     loop {
         print!("Enter the local IP address of your Nanoleaf device or 'Q' to quit: ");
@@ -71,6 +94,11 @@ pub fn get_ip_from_stdin() -> Result<Option<Ipv4Addr>> {
     }
 }
 
+/// Pauses execution until any key is pressed, with TUI-friendly handling.
+///
+/// Temporarily enables raw mode for crossterm event polling.
+/// Loops reading events until Key event received (any key).
+/// Disables raw mode, prints newline, used for user confirmation prompts (e.g., pairing mode).
 pub fn wait_for_any_key() -> Result<()> {
     // Enable raw mode temporarily to detect key presses
     enable_raw_mode()?;
@@ -88,22 +116,57 @@ pub fn wait_for_any_key() -> Result<()> {
     Ok(())
 }
 
+/// Initializes the terminal user interface (TUI) environment.
+///
+/// Enables raw mode for input handling, enters alternate screen buffer,
+/// creates a new ratatui Terminal with CrosstermBackend on stdout.
+///
+/// Called before running the app TUI loop.
+///
+/// # Returns
+///
+/// `Result<Terminal<CrosstermBackend<Stdout>>>` wrapped in impl Backend.
 pub fn init_tui() -> Result<Terminal<impl Backend>> {
     enable_raw_mode()?;
     execute!(stdout(), EnterAlternateScreen)?;
     Terminal::new(CrosstermBackend::new(stdout())).map_err(anyhow::Error::from)
 }
 
+/// Cleans up the TUI environment after app exit.
+///
+/// Disables raw mode and leaves alternate screen to restore normal terminal state.
+/// Called after app run to prevent hanging or corrupted display.
+///
+/// # Errors
+///
+/// Propagates crossterm execution errors.
 pub fn destroy_tui() -> Result<(), anyhow::Error> {
     disable_raw_mode()?;
     execute!(stdout(), LeaveAlternateScreen)?;
     Ok(())
 }
 
+/// Generates a user-friendly error message for failed Nanoleaf device connection.
+///
+/// Formats "couldn't connect to the Nanoleaf device at IP {ip}".
 pub fn generate_connection_error_msg(ip: &Ipv4Addr) -> String {
     format!("couldn't connect to the Nanoleaf device at IP {}", ip)
 }
 
+/// Performs a blocking POST request to a Nanoleaf API endpoint.
+///
+/// Optionally includes JSON body data. Executes and checks status, returns response text.
+///
+/// Used for authenticated API calls requiring POST (e.g., setting effects, panels).
+///
+/// # Arguments
+///
+/// * `url` - Full API URL like "http://ip:16021/api/v1/{token}/..." .
+/// * `data` - Optional JSON value for request body.
+///
+/// # Returns
+///
+/// `Result<String>` - Response body as string, or error if send/status fails.
 pub fn request_post(url: &str, data: Option<&serde_json::Value>) -> Result<String> {
     let mut client = Client::new().post(url);
     if let Some(data) = data {
@@ -116,6 +179,20 @@ pub fn request_post(url: &str, data: Option<&serde_json::Value>) -> Result<Strin
     Ok(res.text()?.to_string())
 }
 
+/// Performs a blocking PUT request to a Nanoleaf API endpoint.
+///
+/// Similar to `request_post`, but uses PUT method. Optional JSON body.
+///
+/// Used for updating resources like panel colors, effects, or layout.
+///
+/// # Arguments
+///
+/// * `url` - API endpoint URL.
+/// * `data` - Optional JSON payload.
+///
+/// # Returns
+///
+/// `Result<String>` - Response text or error on failure.
 pub fn request_put(url: &str, data: Option<&serde_json::Value>) -> Result<String> {
     let mut client = Client::new().put(url);
     if let Some(data) = data {
@@ -128,6 +205,18 @@ pub fn request_put(url: &str, data: Option<&serde_json::Value>) -> Result<String
     Ok(res.text()?.to_string())
 }
 
+/// Performs a blocking GET request to a Nanoleaf API endpoint.
+///
+/// No body, returns response text after status check.
+/// Used for retrieving data like device info, effects list, layout, token auth.
+///
+/// # Arguments
+///
+/// * `url` - API URL to fetch.
+///
+/// # Returns
+///
+/// `Result<String>` - JSON response as string or error.
 pub fn request_get(url: &str) -> Result<String> {
     let client = Client::new().get(url);
     let res = client
@@ -137,6 +226,12 @@ pub fn request_get(url: &str) -> Result<String> {
     Ok(res.text()?.to_string())
 }
 
+/// Generates HWB colors from a list of hues, expanding or truncating to exact count `n`.
+///
+/// Repeats last hue if fewer than `n`, cycles if more? No, resizes vec from hues slice.
+/// Hue=360 special-cased as white (H=0.1, W=1.0, B=0.0); others H=hue f32, W=0, B=1 (saturated full brightness).
+///
+/// Used to map palette hues to panel colors in visualizer.
 pub fn colors_from_hues(hues: &[u16], n: usize) -> Vec<palette::Hwb> {
     let mut res = Vec::from(hues);
     res.resize(n, *hues.last().unwrap());
@@ -190,10 +285,18 @@ pub fn equalize(a: f32, f: u32) -> f32 {
     }
 }
 
+/// Splits a 16-bit unsigned integer into high and low bytes.
+///
+/// Computes high = x >> 8 (or /256), low = x & 0xFF (or %256).
+/// Used for serializing values in Nanoleaf UDP protocol packets.
 pub fn split_into_bytes(x: u16) -> (u8, u8) {
     ((x / 256) as u8, (x % 256) as u8)
 }
 
+/// Creates a ratatui `Line` with effect name characters styled in cycling colors from a palette.
+///
+/// Splits string into individual chars, applies foreground color from `colors` array cycling by index.
+/// Used when `config.tui_config.colorful_effect_names` is true to highlight effect list items.
 pub fn colorful_effect_name<'a>(effect_name: &'a str, colors: &'a [Srgb<u8>]) -> Line<'a> {
     let chars = effect_name.chars().map(|c| c.to_string());
     Line::from(

--- a/src/visualizer.rs
+++ b/src/visualizer.rs
@@ -27,6 +27,13 @@ pub enum VisualizerMsg {
     Resume,
     End,
     SetGain(f32),
+    SetPalette(Vec<u16>),
+    SetSorting {
+        primary_axis: crate::config::Axis,
+        sort_primary: crate::config::Sort,
+        sort_secondary: crate::config::Sort,
+        global_orientation: u16,
+    },
 }
 
 pub struct Visualizer {
@@ -35,7 +42,7 @@ pub struct Visualizer {
     audio_stream: AudioStream,
     gain: f32,
     time_window: f32,
-    trans_time: u16,
+    trans_time: i16,
     min_freq: u16,
     max_freq: u16,
     hues: Vec<u16>,
@@ -49,10 +56,19 @@ impl Visualizer {
     ) -> Result<Self> {
         let state = VisualizerState::default();
         let mut nl_udp = nanoleaf::NlUdp::new(nl_device)?;
-        nl_udp.sort_panels(
+
+        // Get global orientation and apply it when sorting panels
+        let global_orientation = nl_device
+            .get_global_orientation()
+            .ok()
+            .and_then(|o| o["value"].as_u64())
+            .unwrap_or(0) as u16;
+
+        nl_udp.sort_panels_with_orientation(
             config.primary_axis,
             config.sort_primary,
             config.sort_secondary,
+            global_orientation,
         );
         let gain = config.default_gain.unwrap_or(constants::DEFAULT_GAIN);
         let time_window = config.time_window.unwrap_or(constants::DEFAULT_TIME_WINDOW);
@@ -74,12 +90,30 @@ impl Visualizer {
         })
     }
 
-    fn update_state(&mut self, event: VisualizerMsg) {
+    fn update_state(&mut self, event: VisualizerMsg, colors: &mut Vec<palette::Hwb>) {
         match event {
             VisualizerMsg::Resume => self.state = VisualizerState::Running,
             VisualizerMsg::Pause => self.state = VisualizerState::Paused,
             VisualizerMsg::End => self.state = VisualizerState::Done,
             VisualizerMsg::SetGain(gain) => self.gain = gain,
+            VisualizerMsg::SetPalette(hues) => {
+                self.hues = hues;
+                *colors = utils::colors_from_hues(&self.hues, colors.len());
+            }
+            VisualizerMsg::SetSorting {
+                primary_axis,
+                sort_primary,
+                sort_secondary,
+                global_orientation,
+            } => {
+                self.nl_udp.sort_panels_with_orientation(
+                    Some(primary_axis),
+                    Some(sort_primary),
+                    Some(sort_secondary),
+                    global_orientation,
+                );
+                *colors = utils::colors_from_hues(&self.hues, self.nl_udp.panels.len());
+            }
         }
     }
 
@@ -155,10 +189,10 @@ impl Visualizer {
                     VisualizerState::Done => break,
                     VisualizerState::Paused => {
                         let event = rx_events.recv().expect("events sender disconnected");
-                        self.update_state(event);
+                        self.update_state(event, &mut colors);
                     }
                     VisualizerState::Running => match rx_events.try_recv() {
-                        Ok(event) => self.update_state(event),
+                        Ok(event) => self.update_state(event, &mut colors),
                         Err(err) => {
                             if err == TryRecvError::Disconnected {
                                 panic!("events sender disconnected");

--- a/src/visualizer.rs
+++ b/src/visualizer.rs
@@ -1,13 +1,14 @@
 use crate::{
     audio::AudioStream,
-    config::VisualizerConfig,
+    config::{Effect, VisualizerConfig},
     constants,
     nanoleaf::{self, NlDevice, NlUdp},
     panic, processing, utils,
 };
 use anyhow::Result;
-use cpal::{traits::*, InputCallbackInfo, SampleFormat, SizedSample};
+use cpal::{InputCallbackInfo, SampleFormat, SizedSample, traits::*};
 use dasp_sample::conv::ToSample;
+use palette::Oklch;
 use std::{
     sync::mpsc::{self, TryRecvError},
     thread,
@@ -27,7 +28,9 @@ pub enum VisualizerMsg {
     Resume,
     End,
     SetGain(f32),
-    SetPalette(Vec<u16>),
+    SetPalette(Vec<[u8; 3]>),
+    SetEffect(Effect),
+    ResetPanels,
     SetSorting {
         primary_axis: crate::config::Axis,
         sort_primary: crate::config::Sort,
@@ -38,14 +41,16 @@ pub enum VisualizerMsg {
 
 pub struct Visualizer {
     state: VisualizerState,
+    nl_device: NlDevice,
     nl_udp: NlUdp,
     audio_stream: AudioStream,
     gain: f32,
     time_window: f32,
-    trans_time: i16,
+    trans_time: u16,
     min_freq: u16,
     max_freq: u16,
-    hues: Vec<u16>,
+    hues: Vec<[u8; 3]>,
+    effect: Effect,
 }
 
 impl Visualizer {
@@ -94,9 +99,13 @@ impl Visualizer {
             .transition_time
             .unwrap_or(constants::DEFAULT_TRANSITION_TIME);
         let (min_freq, max_freq) = config.freq_range.unwrap_or(constants::DEFAULT_FREQ_RANGE);
-        let hues = config.hues.unwrap_or(Vec::from(constants::DEFAULT_HUES));
+        let hues = config
+            .colors
+            .unwrap_or(Vec::from(constants::DEFAULT_COLORS));
+        let effect = config.effect.unwrap_or_default();
         Ok(Visualizer {
             state,
+            nl_device: nl_device.clone(),
             nl_udp,
             audio_stream,
             gain,
@@ -105,28 +114,67 @@ impl Visualizer {
             min_freq,
             max_freq,
             hues,
+            effect,
         })
+    }
+
+    /// Sends a UDP frame setting all panels to black with instant transition.
+    ///
+    /// Used when starting the visualizer or changing effects/palettes to clear
+    /// any lingering colors from the previous state before the new effect begins.
+    fn send_black_frame(&self, n_panels: usize) {
+        let black = vec![Oklch::new(0.0, 0.0, 0.0); n_panels];
+        let _ = self.nl_udp.update_panels(&black, 0);
     }
 
     /// Updates visualizer internal state or parameters based on received message.
     ///
     /// Dispatched in processing thread loop.
-    /// Modifies self fields and/or regenerates `colors` vector from hues.
+    /// Modifies self fields and/or regenerates `base_colors` vector from hues.
+    /// When palette or sorting changes, brightness is reset to 0 so panels start dark.
     /// For SetSorting, updates UDP panel order with orientation.
     ///
     /// # Arguments
     ///
     /// * `event` - Control message type.
-    /// * `colors` - Mutable reference to current HWB color array for panels (updated if palette/sort changes).
-    fn update_state(&mut self, event: VisualizerMsg, colors: &mut Vec<palette::Hwb>) {
+    /// * `base_colors` - Mutable reference to base Oklch colors with original lightness (updated if palette/sort changes).
+    /// * `brightness` - Mutable reference to per-panel brightness multipliers (reset on palette/sort changes).
+    /// * `prev_max` - Mutable reference to previous max amplitudes (reset on effect change).
+    /// * `speed` - Mutable reference to velocity/phase accumulators (reset on effect change).
+    fn update_state(
+        &mut self,
+        event: VisualizerMsg,
+        base_colors: &mut Vec<Oklch>,
+        brightness: &mut Vec<f32>,
+        prev_max: &mut Vec<f32>,
+        speed: &mut Vec<f32>,
+    ) {
         match event {
             VisualizerMsg::Resume => self.state = VisualizerState::Running,
             VisualizerMsg::Pause => self.state = VisualizerState::Paused,
             VisualizerMsg::End => self.state = VisualizerState::Done,
             VisualizerMsg::SetGain(gain) => self.gain = gain,
-            VisualizerMsg::SetPalette(hues) => {
-                self.hues = hues;
-                *colors = utils::colors_from_hues(&self.hues, colors.len());
+            VisualizerMsg::SetEffect(effect) => {
+                self.effect = effect;
+                brightness.fill(0.0);
+                // Reset state arrays — each effect uses prev_max/speed differently
+                prev_max.fill(0.0);
+                speed.fill(0.0);
+                // Immediately send a black frame so the old effect's colors don't linger
+                self.send_black_frame(base_colors.len());
+            }
+            VisualizerMsg::SetPalette(new_colors) => {
+                self.hues = new_colors;
+                *base_colors = utils::colors_from_rgb(&self.hues, base_colors.len());
+                brightness.fill(0.0);
+                // Immediately send a black frame so the old palette's colors don't linger
+                self.send_black_frame(base_colors.len());
+            }
+            VisualizerMsg::ResetPanels => {
+                brightness.fill(0.0);
+                prev_max.fill(0.0);
+                speed.fill(0.0);
+                self.send_black_frame(base_colors.len());
             }
             VisualizerMsg::SetSorting {
                 primary_axis,
@@ -140,7 +188,11 @@ impl Visualizer {
                     Some(sort_secondary),
                     global_orientation,
                 );
-                *colors = utils::colors_from_hues(&self.hues, self.nl_udp.panels.len());
+                *base_colors = utils::colors_from_rgb(&self.hues, self.nl_udp.panels.len());
+                brightness.resize(base_colors.len(), 0.0);
+                brightness.fill(0.0);
+                // Immediately send a black frame so the old sort order's colors don't linger
+                self.send_black_frame(base_colors.len());
             }
         }
     }
@@ -192,8 +244,10 @@ impl Visualizer {
     /// Spawns thread that:
     /// - Registers panic handler.
     /// - Loops receiving audio samples and control messages.
-    /// - Processes FFT spectrum, updates colors with gain/time_window/equalize.
-    /// - Applies sorting and sends HWB colors to panels via UDP with transition time.
+    /// - Processes FFT spectrum, updates per-panel brightness multiplier [0,1] from audio.
+    /// - Computes display colors: for each panel, scales base Oklch lightness by brightness,
+    ///   so at peak audio the output exactly matches the user's original RGB palette color.
+    /// - Sends display colors to panels via UDP with transition time.
     /// - Handles pause/resume/end states.
     ///
     /// Returns sender for sending `VisualizerMsg` to control runtime behavior.
@@ -236,19 +290,37 @@ impl Visualizer {
             stream.play().expect("running the audio stream failed");
 
             let n = self.nl_udp.panels.len();
-            let sample_rate = self.audio_stream.stream_config.sample_rate.0;
-            let mut colors = utils::colors_from_hues(&self.hues, n);
+            let sample_rate = self.audio_stream.stream_config.sample_rate;
+            // Base colors hold the target Oklch values (with original lightness from the user's RGB)
+            let mut base_colors = utils::colors_from_rgb(&self.hues, n);
+            // Brightness multiplier [0,1] per panel — animated by audio amplitude
+            // At 0 the panel is black; at 1 it shows the exact target color
+            let mut brightness = vec![0.0_f32; n];
             let mut prev_max = vec![0.0; n];
             let mut speed = vec![0.0; n];
+            // Clear any colors left over from a previous Nanoleaf scene or effect
+            self.send_black_frame(n);
             loop {
                 match self.state {
                     VisualizerState::Done => break,
                     VisualizerState::Paused => {
                         let event = rx_events.recv().expect("events sender disconnected");
-                        self.update_state(event, &mut colors);
+                        self.update_state(
+                            event,
+                            &mut base_colors,
+                            &mut brightness,
+                            &mut prev_max,
+                            &mut speed,
+                        );
                     }
                     VisualizerState::Running => match rx_events.try_recv() {
-                        Ok(event) => self.update_state(event, &mut colors),
+                        Ok(event) => self.update_state(
+                            event,
+                            &mut base_colors,
+                            &mut brightness,
+                            &mut prev_max,
+                            &mut speed,
+                        ),
                         Err(err) => {
                             if err == TryRecvError::Disconnected {
                                 panic!("events sender disconnected");
@@ -264,18 +336,48 @@ impl Visualizer {
                 }
                 let spectrum = processing::process(samples, self.gain);
                 let hz_per_bin = (sample_rate / 2) / (spectrum.len() as u32);
-                processing::update_colors(
-                    spectrum,
-                    hz_per_bin,
-                    self.min_freq,
-                    self.max_freq,
-                    &mut colors,
-                    &mut prev_max,
-                    &mut speed,
-                );
-                self.nl_udp
-                    .update_panels(&colors, self.trans_time)
-                    .expect("updating panels failed");
+                match self.effect {
+                    Effect::Spectrum => processing::update_brightness(
+                        spectrum,
+                        hz_per_bin,
+                        self.min_freq,
+                        self.max_freq,
+                        &mut brightness,
+                        &mut prev_max,
+                        &mut speed,
+                    ),
+                    Effect::EnergyWave => processing::update_brightness_wave(
+                        spectrum,
+                        hz_per_bin,
+                        self.min_freq,
+                        self.max_freq,
+                        &mut brightness,
+                        &mut prev_max,
+                        &mut speed,
+                    ),
+                    Effect::Pulse => processing::update_brightness_pulse(
+                        spectrum,
+                        hz_per_bin,
+                        self.min_freq,
+                        self.max_freq,
+                        &mut brightness,
+                        &mut prev_max,
+                        &mut speed,
+                    ),
+                }
+                // Compute display colors: scale base lightness by brightness multiplier
+                // This ensures at brightness=1.0, the output exactly matches the user's original RGB
+                let display_colors: Vec<Oklch> = base_colors
+                    .iter()
+                    .zip(brightness.iter())
+                    .map(|(base, &b)| Oklch::new(base.l * b, base.chroma, base.hue))
+                    .collect();
+                if let Err(_) = self.nl_udp.update_panels(&display_colors, self.trans_time) {
+                    // UDP send failed (e.g. extControl timed out) — re-request and retry once
+                    if self.nl_device.request_udp_control().is_ok() {
+                        let _ = self.nl_udp.update_panels(&display_colors, self.trans_time);
+                    }
+                }
             }
         });
 

--- a/src/visualizer.rs
+++ b/src/visualizer.rs
@@ -49,6 +49,24 @@ pub struct Visualizer {
 }
 
 impl Visualizer {
+    /// Initializes a new `Visualizer` instance with configuration and resources.
+    ///
+    /// Sets up UDP controller for panel updates, fetches global orientation from device for sorting.
+    /// Applies config values or defaults for gain, time_window, etc.
+    /// Sorts panels according to primary/secondary axes and sorts.
+    ///
+    /// Note: Audio stream is moved in, but actually played in `init()`.
+    /// Does not start audio capture or visualization loop yet.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - VisualizerConfig with params like freq_range, hues, gain.
+    /// * `audio_stream` - Pre-configured CPAL input stream device/config.
+    /// * `nl_device` - Connected Nanoleaf device for UDP and API calls.
+    ///
+    /// # Errors
+    ///
+    /// From `NlUdp::new` if UDP setup fails, or device API for orientation.
     pub fn new(
         config: VisualizerConfig,
         audio_stream: AudioStream,
@@ -90,6 +108,16 @@ impl Visualizer {
         })
     }
 
+    /// Updates visualizer internal state or parameters based on received message.
+    ///
+    /// Dispatched in processing thread loop.
+    /// Modifies self fields and/or regenerates `colors` vector from hues.
+    /// For SetSorting, updates UDP panel order with orientation.
+    ///
+    /// # Arguments
+    ///
+    /// * `event` - Control message type.
+    /// * `colors` - Mutable reference to current HWB color array for panels (updated if palette/sort changes).
     fn update_state(&mut self, event: VisualizerMsg, colors: &mut Vec<palette::Hwb>) {
         match event {
             VisualizerMsg::Resume => self.state = VisualizerState::Running,
@@ -117,6 +145,14 @@ impl Visualizer {
         }
     }
 
+    /// Converts interleaved multi-channel audio data to mono envelope (max per frame) and sends to channel.
+    ///
+    /// Processes audio callback data: for each set of `n_channels` samples, converts to f32,
+    /// takes maximum absolute value as simplified mono amplitude envelope.
+    /// Sends Vec<f32> of these envelopes to mpsc channel for FFT processing.
+    ///
+    /// Generic over sample type T supporting sized conversion to f32.
+    /// Used in `create_data_callback` closure for CPAL stream.
     fn send_samples<T>(data: &[T], n_channels: usize, tx: &mpsc::Sender<Vec<f32>>)
     where
         T: SizedSample + ToSample<f32>,
@@ -133,6 +169,13 @@ impl Visualizer {
         tx.send(samples).expect("sending samples failed");
     }
 
+    /// Creates a closure suitable for CPAL `build_input_stream` callback.
+    ///
+    /// Captures `n_channels` and `tx` sender, returns `send_samples` bound to them.
+    /// The closure ignores `InputCallbackInfo` (timestamp not used).
+    /// Ensures Send + 'static for thread-safe stream usage.
+    ///
+    /// Generic T for sample type matching AudioStream format.
     fn create_data_callback<T>(
         n_channels: usize,
         tx: mpsc::Sender<Vec<f32>>,
@@ -143,6 +186,19 @@ impl Visualizer {
         move |data: &[T], _: &InputCallbackInfo| Self::send_samples(data, n_channels, &tx)
     }
 
+    /// Completes visualizer setup by starting audio capture stream and spawning processing thread.
+    ///
+    /// Builds and plays CPAL input stream matched to sample format, sending mono max samples via channel.
+    /// Spawns thread that:
+    /// - Registers panic handler.
+    /// - Loops receiving audio samples and control messages.
+    /// - Processes FFT spectrum, updates colors with gain/time_window/equalize.
+    /// - Applies sorting and sends HWB colors to panels via UDP with transition time.
+    /// - Handles pause/resume/end states.
+    ///
+    /// Returns sender for sending `VisualizerMsg` to control runtime behavior.
+    ///
+    /// Consumes self (moved into thread closure).
     pub fn init(mut self) -> mpsc::Sender<VisualizerMsg> {
         let (tx_events, rx_events) = mpsc::channel();
         thread::spawn(move || {


### PR DESCRIPTION
## Summary

- **Album art visualizer**: Press `N` in visualizer view to extract colors from the currently playing track's album art (Spotify and Apple Music via ScriptingBridge + osascript fallback). Auto-updates on song change via background watcher thread.
- **TUI enhancements**: Shows "Now playing: *track title*" and color swatches of the active palette in the visualizer view.
- **Color extraction**: Uses `auto-palette` crate with Oklch lightness filtering to extract the 4 most dominant album art colors, filtering out near-black colors that can't be represented on panels.
- **Even color distribution**: Palette colors spread evenly across all panels instead of padding the last color to fill remaining slots.
- **Universal macOS binary**: Added `Makefile` with `make universal` target (lipo x86_64 + aarch64) and updated CI to build universal binary on macOS.
- **Formatting**: Fixed `cargo fmt` issues that were failing CI.

## Test plan

- [ ] Play a track on Spotify, enter visualizer (`V`), press `N` — verify album art colors appear on panels and in TUI
- [ ] Play a track on Apple Music, press `N` — verify artwork extracted via ScriptingBridge or osascript fallback
- [ ] Change songs while album art mode is active — verify colors auto-update within ~3 seconds
- [ ] Press a number key (`1`-`0`) to switch back to a named palette — verify watcher stops
- [ ] Verify color swatches display correctly in TUI for both named and album art palettes
- [ ] Run `make universal` on macOS — verify fat binary is produced
- [ ] CI passes on all platforms (ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)